### PR TITLE
Set method refactor

### DIFF
--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -1,4 +1,5 @@
 # window.rb
+require 'pry'
 
 module Ruby2D
   class Window
@@ -38,16 +39,15 @@ module Ruby2D
     end
     
     def set(opts)
-      if opts.include? :title
-        @title = opts[:title]
-      end
-      
-      if opts.include? :width
-        @width = opts[:width]
-      end
-      
-      if opts.include? :height
-        @height = opts[:height]
+      valid_keys = [:title, :width, :height]
+      valid_opts = opts.reject { |k| !valid_keys.include?(k) }
+      if !valid_opts.empty?
+        @title = valid_opts[:title]
+        @width = valid_opts[:width]
+        @height = valid_opts[:height]
+        return true
+      else
+        return false
       end
     end
     

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -1,5 +1,4 @@
 # window.rb
-require 'pry'
 
 module Ruby2D
   class Window

--- a/tests/testcard.rb
+++ b/tests/testcard.rb
@@ -1,6 +1,5 @@
 require 'ruby2d'
 
-binding.pry
 set width: 700, height: 500, title: "Ruby 2D – Testcard"
 
 # Read window attributes

--- a/tests/testcard.rb
+++ b/tests/testcard.rb
@@ -1,5 +1,6 @@
 require 'ruby2d'
 
+binding.pry
 set width: 700, height: 500, title: "Ruby 2D – Testcard"
 
 # Read window attributes


### PR DESCRIPTION

in previous implementation, set method was returning either the value of `@height` or `nil` (as evaluated by final `if` statement).
returning boolean to reflect either successful or unsuccessful assignment seems to match `return` patterns in other `Window` methods (e.g. `#add`, `#remove`).
\+ @sophiedebenedetto