### PR TITLE
Implemented rgb hex to float conversion fixes issue #1

### DIFF
--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -67,6 +67,20 @@ module Ruby2D
       end
       return b
     end
+    #convert from "#FFF000" to Float (0.0..1.0) 
+    def hex_to_f(a)
+      c=[]	    
+      b=a.delete("#")
+      n=(b.length)
+      #n1=n/3
+      j=0
+      for i in (0..n-1).step(n/3)
+      	c[j]=Integer("0x".concat(b[i,n/3]))
+	j=j+1
+      end
+      f = to_f(c)
+      return f
+    end
     
   end
 end


### PR DESCRIPTION
The algorithm 1st converts any length rgb hex value to a fixnum(0..255) then it calls to_f() function where it gets converted to float . 
@blacktm , Please review it if any changes need to be done please suggest me 
Thank You :)