### PR TITLE
Text#text= will inspect it's input

### DIFF
--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -235,14 +235,14 @@ static R_VAL ruby2d_text_init(R_VAL self) {
 
 
 /*
- * Ruby2D::Text#text=
+ * Ruby2D::Text#ext_text_set
  */
 #if MRUBY
-static R_VAL ruby2d_text_equals(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_ext_text_set(mrb_state* mrb, R_VAL self) {
   mrb_value text;
   mrb_get_args(mrb, "o", &text);
 #else
-static R_VAL ruby2d_text_equals(R_VAL self, R_VAL text) {
+static R_VAL ruby2d_ext_text_set(R_VAL self, R_VAL text) {
   r_iv_set(self, "@text", text);
 #endif
   
@@ -748,8 +748,8 @@ void Init_ruby2d() {
   // Ruby2D::Text#init
   r_define_method(ruby2d_text_class, "init", ruby2d_text_init, r_args_none);
   
-  // Ruby2D::Text#text=
-  r_define_method(ruby2d_text_class, "text=", ruby2d_text_equals, r_args_req(1));
+  // Ruby2D::Text#ext_text_set
+  r_define_method(ruby2d_text_class, "ext_text_set", ruby2d_ext_text_set, r_args_req(1));
   
   // Ruby2D::Sound
   R_CLASS ruby2d_sound_class = r_define_class(ruby2d_module, "Sound");

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -16,10 +16,15 @@ module Ruby2D
       
       @type_id = 5
       @x, @y, @size = x, y, size
-      @text = text
+      @text = text.to_s
       @color = Color.new(c)
       init
       add
+    end
+    
+    def text=(msg)
+      @text = msg.to_s
+      ext_text_set(@text)
     end
     
     def color=(c)

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -1,0 +1,18 @@
+require 'ruby2d'
+
+RSpec.describe Ruby2D::Text do
+  
+  describe '#text=' do
+    it 'maps Time to string' do
+      t = Text.new(0, 0, Time.now, 40, "test/media/bitstream_vera/vera.ttf")
+      t.text = Time.new(1, 1, 1, 1, 1, 1, 1)
+      expect(t.text).to eq "0001-01-01 01:01:01 +0000"
+    end
+    
+    it 'maps Number to string' do
+      t = Text.new(0, 0, 0, 40, "test/media/bitstream_vera/vera.ttf")
+      t.text = 0
+      expect(t.text).to eq "0"
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes sure that text passed to Text in initializer, and subsequent texts passed via Text#text= will be inspected. This allows user to pass any ruby object to Text#text=, such as numbers, time and others.

Without these changes passing numbers crashes the program, and passing time shows garbage.
I also added test to make sure that it works properly in all environments, and as far as I know it does work properly in MRI on ubuntu 16.04, native in ubuntu 16.04 and in web.

In web the size of passed time is smaller than expected, but this is probably a different issue.