### PR TITLE
Implement Color#opacity=

### DIFF
--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -2,6 +2,26 @@
 
 module Ruby2D
   class Color
+    # Color::Set represents an array of colors
+    class Set
+      def initialize(colors)
+        @colors = colors.map{|c| Color.new(c)}
+      end
+
+      def [](i)
+        @colors[i]
+      end
+
+      def length
+        @colors.length
+      end
+
+      def opacity=(opacity)
+        @colors.each do |color|
+          color.opacity = opacity
+        end
+      end
+    end
     
     attr_reader :r, :g, :b, :a
     
@@ -64,6 +84,20 @@ module Ruby2D
       c.all? { |el|
         el.is_a?(Numeric) && (0.0..1.0).include?(el)
       }
+    end
+
+    def self.from(input)
+      # If a valid array of colors, return a Color::Set with those colors
+      # Else return single color
+      if input.is_a? Array and input.all? { |el| Color.is_valid? el }
+        Color::Set.new(input)
+      else
+        Color.new(input)
+      end
+    end
+
+    def opacity=(opacity)
+      @a = opacity
     end
     
     private

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -17,14 +17,14 @@ module Ruby2D
     def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white')
       @type_id = 2
       @x1, @y1, @x2, @y2, @x3, @y3, @x4, @y4 = x1, y1, x2, y2, x3, y3, x4, y4
-      @color = c
-      update_color(c)
+      
+      self.color = c
       add
     end
     
     def color=(c)
-      @color = c
-      update_color(c)
+      @color = Color.from(c)
+      update_color(@color)
     end
     
     def add
@@ -42,30 +42,21 @@ module Ruby2D
     private
     
     def update_color(c)
-      
-      # If a valid color, use it for each vertex
-      if Color.is_valid? c
-        @c1 = Color.new(c)
-        @c2 = Color.new(c)
-        @c3 = Color.new(c)
-        @c4 = Color.new(c)
-        
-      elsif c.class == Array && c.length < 4
-        raise Error, "Quads require 4 colors, one for each vertex. Only " <<
-                     "#{c.length} were given."
-        
-      # If a valid array of colors, assign them to each vertex, respectively
-      elsif c.all? { |el| Color.is_valid? el }
-        @c1 = Color.new(c[0])
-        @c2 = Color.new(c[1])
-        @c3 = Color.new(c[2])
-        @c4 = Color.new(c[3])
-        
+      if c.is_a? Color::Set
+        if c.length == 4
+          @c1 = c[0]
+          @c2 = c[1]
+          @c3 = c[2]
+          @c4 = c[3]
+        else
+          raise ArgumentError, "Quads require 4 colors, one for each vertex. #{c.length} were given."
+        end
       else
-        raise Error, "Not a valid color for #{self.class}"
+        @c1 = c
+        @c2 = c
+        @c3 = c
+        @c4 = c
       end
-      
     end
-    
   end
 end

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -7,9 +7,10 @@ module Ruby2D
     
     def initialize(x=0, y=0, w=200, h=100, c='white')
       @type_id = 2
-      @x, @y, @width, @height, @color = x, y, w, h, c
+      @x, @y, @width, @height = x, y, w, h
       update_coords(x, y, w, h)
-      update_color(c)
+
+      self.color = c
       add
     end
     

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -7,10 +7,11 @@ module Ruby2D
     
     def initialize(x=0, y=0, s=100, c='white')
       @type_id = 2
-      @x, @y, @color = x, y, c
+      @x, @y = x, y
       @width = @height = @size = s
       update_coords(x, y, s, s)
-      update_color(c)
+
+      self.color = c
       add
     end
     

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -17,7 +17,7 @@ module Ruby2D
       @type_id = 5
       @x, @y, @size = x, y, size
       @text = text.to_s
-      @color = Color.new(c)
+      self.color = c
       init
       add
     end

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -13,14 +13,14 @@ module Ruby2D
       @x1, @y1 = x1, y1
       @x2, @y2 = x2, y2
       @x3, @y3 = x3, y3
-      @color = c
-      update_color(c)
+
+      self.color = c
       add
     end
     
     def color=(c)
-      update_color(c)
-      @color = c
+      @color = Color.from(c)
+      update_color(@color)
     end
     
     def add
@@ -38,28 +38,19 @@ module Ruby2D
     private
     
     def update_color(c)
-      
-      # If a valid color, use it for each vertex
-      if Color.is_valid? c
-        @c1 = Color.new(c)
-        @c2 = Color.new(c)
-        @c3 = Color.new(c)
-        
-      elsif c.class == Array && c.length < 3
-        raise Error, "Triangles require 3 colors, one for each vertex. Only " <<
-                     "#{c.length} were given."
-        
-      # If a valid array of colors, assign them to each vertex, respectively
-      elsif c.all? { |el| Color.is_valid? el }
-        @c1 = Color.new(c[0])
-        @c2 = Color.new(c[1])
-        @c3 = Color.new(c[2])
-        
+      if c.is_a? Color::Set
+        if c.length == 3
+          @c1 = c[0]
+          @c2 = c[1]
+          @c3 = c[2]
+        else
+          raise ArgumentError, "Triangles require 3 colors, one for each vertex. #{c.length} were given."
+        end
       else
-        raise Error, "Not a valid color for #{self.class}"
+        @c1 = c
+        @c2 = c
+        @c3 = c
       end
-      
     end
-    
   end
 end

--- a/test/quad_spec.rb
+++ b/test/quad_spec.rb
@@ -1,0 +1,92 @@
+require 'ruby2d'
+
+RSpec.describe Ruby2D::Quad do
+  describe '#new' do
+    it "creates a quad with white color by default" do
+      quad = Quad.new(
+        300, 200,
+        350, 200,
+        300, 250,
+        250, 250
+      )
+
+      expect(quad.color).to   be_a(Ruby2D::Color)
+      expect(quad.color.r).to eq(1)
+      expect(quad.color.g).to eq(1)
+      expect(quad.color.b).to eq(1)
+      expect(quad.color.a).to eq(1)
+    end
+
+    it 'creates a new quad with one color via string' do
+      quad = Quad.new(
+        300, 200,
+        350, 200,
+        300, 250,
+        250, 250,
+        "red"
+      )
+
+      expect(quad.color).to be_a(Ruby2D::Color)
+    end
+
+    it "creates a new triangle with one color via array of numbers" do
+      quad = Quad.new(
+        300, 200,
+        350, 200,
+        300, 250,
+        250, 250,
+        [0.1, 0.3, 0.5, 0.7]
+      )
+
+      expect(quad.color).to be_a(Ruby2D::Color)
+    end
+
+    it "creates a new quad with 4 colors via array of 4 strings" do
+      quad = Quad.new(
+        300, 200,
+        350, 200,
+        300, 250,
+        250, 250,
+        ["red", "green", "blue", "black"]
+      )
+
+      expect(quad.color).to be_a(Ruby2D::Color::Set)
+    end
+
+    it "creates a new quad with 4 colors via array of 4 arrays of arrays of numbers" do
+      quad = Quad.new(
+        300, 200,
+        350, 200,
+        300, 250,
+        250, 250,
+        [[0.1, 0.3, 0.5, 0.7], [0.2, 0.4, 0.6, 0.8], [0.3, 0.5, 0.7, 0.9], [0.4, 0.6, 0.8, 1.0]]
+      )
+
+      expect(quad.color).to be_a(Ruby2D::Color::Set)
+    end
+
+    it "throws an error when array of 3 strings is passed" do
+      expect do
+        Quad.new(
+          300, 200,
+          350, 200,
+          300, 250,
+          250, 250,
+          ["red", "green", "blue"]
+        )
+      end.to raise_error("Quads require 4 colors, one for each vertex. 3 were given.")
+    end
+
+    it "throws an error when array of 5 strings is passed" do
+      expect do
+        Quad.new(
+          300, 200,
+          350, 200,
+          300, 250,
+          250, 250,
+          ["red", "green", "blue", "black", "fuchsia"]
+        )
+      end.to raise_error("Quads require 4 colors, one for each vertex. 5 were given.")
+    end
+  end
+end

--- a/test/testcard.rb
+++ b/test/testcard.rb
@@ -175,6 +175,10 @@ pointer = Square.new(0, 0, 10, [1, 1, 1, 1])
 pointer_outline = Square.new(0, 0, 18, [0, 1, 0, 0])
 flash = 0
 
+# Updating opacity
+opacity_square = Square.new(500, 255, 50, ["red", "green", "blue", "yellow"])
+time_start     = Time.now
+
 on key: 'escape' do
   close
 end
@@ -202,6 +206,10 @@ update do
   if (get :frames) % 20 == 0
     fps.text = "FPS: #{(get :fps).round(3)}"
   end
+
+  elapsed_time = Time.now - time_start
+  opacity = Math.sin(3 * elapsed_time.to_f).abs
+  opacity_square.color.opacity = opacity
 end
 
 show

--- a/test/triangle_spec.rb
+++ b/test/triangle_spec.rb
@@ -1,0 +1,82 @@
+require 'ruby2d'
+
+RSpec.describe Ruby2D::Triangle do
+  describe '#new' do
+    it "creates a triangle with white color by default" do
+      triangle = Triangle.new(
+        320,  50,
+        540, 430,
+        100, 430
+      )
+      expect(triangle.color).to   be_a(Ruby2D::Color)
+      expect(triangle.color.r).to eq(1)
+      expect(triangle.color.g).to eq(1)
+      expect(triangle.color.b).to eq(1)
+      expect(triangle.color.a).to eq(1)
+    end
+
+    it 'creates a new triangle with one color via string' do
+      triangle = Triangle.new(
+        320,  50,
+        540, 430,
+        100, 430,
+        "black"
+      )
+
+      expect(triangle.color).to be_a(Ruby2D::Color)
+    end
+
+    it "creates a new triangle with one color via array of numbers" do
+      triangle = Triangle.new(
+        320,  50,
+        540, 430,
+        100, 430,
+        [0.1, 0.3, 0.5, 0.7]
+      )
+
+      expect(triangle.color).to be_a(Ruby2D::Color)
+    end
+
+    it "creates a new triangle with 3 colors via array of 3 strings" do
+      triangle = Triangle.new(
+        320,  50,
+        540, 430,
+        100, 430,
+        ["red", "green", "blue"]
+      )
+      expect(triangle.color).to be_a(Ruby2D::Color::Set)
+    end
+
+    it "creates a new triangle with 3 colors via array of 3 arrays of arrays of numbers" do
+      triangle = Triangle.new(
+        320,  50,
+        540, 430,
+        100, 430,
+        [[0.1, 0.3, 0.5, 0.7], [0.2, 0.4, 0.6, 0.8], [0.3, 0.5, 0.7, 0.9]]
+      )
+      expect(triangle.color).to be_a(Ruby2D::Color::Set)
+    end
+
+    it "throws an error when array of 2 strings is passed" do
+      expect do
+        Triangle.new(
+          320,  50,
+          540, 430,
+          100, 430,
+          ["red", "green"]
+        )
+      end.to raise_error("Triangles require 3 colors, one for each vertex. 2 were given.")
+    end
+
+    it "throws an error when array of 4 strings is passed" do
+      expect do
+        Triangle.new(
+          320,  50,
+          540, 430,
+          100, 430,
+          ["red", "green", "blue", "fuchsia"]
+        )
+      end.to raise_error("Triangles require 3 colors, one for each vertex. 4 were given.")
+    end
+  end
+end


### PR DESCRIPTION
In the game I'm working on I have a couple of places in which I have a shape on map, that is expected to stay, and only change opacity in time. Those are things like mask that covers map when it's night, or visual effects of a fireplace (yellow rectangle that changes opacity over time to reflects light flickering).

In those places I currently have to update completely new color every time, which forces me to write some boilerplate code. It's also suboptimal, by allocating array of numbers as color with each change.

With this pull request I would like to suggest an implementation of `Color#opacity=` method, that allows updating the opacity of existing color.

Since rectangles, squares, quads and triangles are allowed to have different color per vertex, I added Color::Set class to be a wrapper over an array of colors, with #opacity= method to update each color in array.

I also made sure that implementation looks the same for each object that exposes #color getter, and that it works for each of those objects (color.rb test) in mri, native and in browser, on linux 16.04 at least.

I am fairly certain that those changes introduce no change in external api of those classes.

Please treat this PR as a suggestion, and a start of a discussion for existance of such method: I have no expectation for this to be merged if you don't wish such feature or like this implementation.