### PR TITLE
WIP Implement Text#width and Text#height

### DIFF
--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -130,7 +130,6 @@ function render() {
 
 
 module Ruby2D
-  
   class Image
     def init(path)
       `#{self}.data = S2D.CreateImage(path);`
@@ -146,11 +145,14 @@ module Ruby2D
   class Text
     def init
       `#{self}.data = S2D.CreateText(#{self}.font, #{self}.text, #{self}.size);`
+      @width  = `#{self}.data.width;`
+      @height = `#{self}.data.height;`
     end
     
-    def text=(t)
-      @text = t
-      `S2D.SetText(#{self}.data, #{self}.text);`
+    def ext_text_set(msg)
+      `S2D.SetText(#{self}.data, #{msg});`
+      @width  = `#{self}.data.width;`
+      @height = `#{self}.data.height;`
     end
   end
   

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -229,6 +229,9 @@ static R_VAL ruby2d_text_init(R_VAL self) {
     NUM2DBL(r_iv_get(self, "@size"))
   );
   
+  r_iv_set(self, "@width", INT2NUM(txt->width));
+  r_iv_set(self, "@height", INT2NUM(txt->height));
+  
   r_iv_set(self, "@data", r_data_wrap_struct(text, txt));
   return R_NIL;
 }
@@ -245,14 +248,14 @@ static R_VAL ruby2d_ext_text_set(mrb_state* mrb, R_VAL self) {
 static R_VAL ruby2d_ext_text_set(R_VAL self, R_VAL text) {
   r_iv_set(self, "@text", text);
 #endif
-  
-  // If called before window is shown, return
-  if (!r_test(ruby2d_window)) return R_NIL;
-  
   S2D_Text *txt;
   r_data_get_struct(self, "@data", &text_data_type, S2D_Text, txt);
   
   S2D_SetText(txt, RSTRING_PTR(text));
+  
+  r_iv_set(self, "@width", INT2NUM(txt->width));
+  r_iv_set(self, "@height", INT2NUM(txt->height));
+  
   return R_NIL;
 }
 

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -4,7 +4,7 @@ module Ruby2D
   class Text
     
     attr_accessor :x, :y, :data
-    attr_reader :text, :size, :font, :color
+    attr_reader :text, :size, :width, :height, :font, :color
     
     def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c="white")
       

--- a/test/testcard.rb
+++ b/test/testcard.rb
@@ -179,6 +179,30 @@ flash = 0
 opacity_square = Square.new(500, 255, 50, ["red", "green", "blue", "yellow"])
 time_start     = Time.now
 
+# Text size
+created_text = Text.new(10, 270, "Created text", 20, font)
+created_text_background = Rectangle.new(
+  created_text.x - 10,
+  created_text.y - 10,
+  created_text.width + 20,
+  created_text.height + 20,
+  "red"
+)
+created_text.remove
+created_text.add
+
+updated_text = Text.new(20 + created_text_background.x2, 270, "Updated text", 20, font)
+updated_text_background = Rectangle.new(
+  updated_text.x - 10,
+  updated_text.y - 10,
+  updated_text.width + 20,
+  updated_text.height + 20,
+  "blue"
+)
+updated_text.remove
+updated_text.add
+UPDATED_TEXT_OPTIONS = "of various size".split(" ")
+
 on key: 'escape' do
   close
 end
@@ -210,6 +234,11 @@ update do
   elapsed_time = Time.now - time_start
   opacity = Math.sin(3 * elapsed_time.to_f).abs
   opacity_square.color.opacity = opacity
+
+  if (get :frames) % 60 == 0
+    updated_text.text = "Updated text " + UPDATED_TEXT_OPTIONS[Time.now.to_i % UPDATED_TEXT_OPTIONS.length]
+    updated_text_background.width = updated_text.width + 20
+  end
 end
 
 show

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -15,4 +15,30 @@ RSpec.describe Ruby2D::Text do
       expect(t.text).to eq "0"
     end
   end
+
+  describe "#width" do
+    it "is known after creation" do
+      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
+      expect(t.width).to eq(239)
+    end
+
+    it "is known after updating" do
+      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
+      t.text = "Hello world!"
+      expect(t.width).to eq(239)
+    end
+  end
+
+  describe "#height" do
+    it "is known after creation" do
+      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
+      expect(t.height).to eq(48)
+    end
+
+    it "is known after updating" do
+      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
+      t.text = "Hello world!"
+      expect(t.height).to eq(48)
+    end
+  end
 end


### PR DESCRIPTION
As in the title, I implemented those 2 methods, and it works fine(ish) in testcard on MRI, native and in browser. I am not 100% sure if browser version is acceptable, but this is the solution I came up with.

However, some tests are not passing. I think this is due to this line: https://github.com/ruby2d/ruby2d/blob/master/ext/ruby2d/ruby2d.c#L250

When window is not present, it never gets to the text updating code. Given this issue, and the https://github.com/ruby2d/ruby2d/issues/35, I think that Text#ext_text_set needs to be a little bit reorganised to account for those issues.

Other way would be to only write tests like this:

```
  describe "#width" do 
    it "does not segfault after creation" do 
      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
      t.width
    end

    it "does not segfault after updating" do 
      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
      t.text = "Hello world!"
      t.width
    end
  end

  describe "#height" do 
    it "does not segfault after creation" do 
      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
      t.height
    end

    it "does not segfault after updating" do 
      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
      t.text = "Hello world!"
      t.height
    end
  end
```
Which would also sort-of work, since texts size isn't all that important until window is rendered.

Thoughts?