### PR TITLE
introduce Ruby2D::Renderable

### DIFF
--- a/bin/ruby2d
+++ b/bin/ruby2d
@@ -14,6 +14,7 @@ end
 
 # The Ruby 2D library files
 @lib_files = [
+  'renderable',
   'exceptions',
   'color',
   'window',

--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -1,5 +1,6 @@
 # ruby2d.rb
 
+require 'ruby2d/renderable'
 require 'ruby2d/exceptions'
 require 'ruby2d/color'
 require 'ruby2d/window'

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -2,7 +2,8 @@
 
 module Ruby2D
   class Image
-    
+    include Renderable
+
     attr_accessor :x, :y, :width, :height, :data
     attr_reader :path, :color
     
@@ -25,18 +26,5 @@ module Ruby2D
     def color=(c)
       @color = Color.new(c)
     end
-    
-    def add
-      if Module.const_defined? :DSL
-        Application.add(self)
-      end
-    end
-    
-    def remove
-      if Module.const_defined? :DSL
-        Application.remove(self)
-      end
-    end
-    
   end
 end

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -1,7 +1,8 @@
 # quad.rb
 
 module Ruby2D
-  class Quad
+  class Quad 
+    include Renderable
     # Coordinates in clockwise order, starting at top left:
     # x1,y1 == top left
     # x2,y2 == top right
@@ -25,18 +26,6 @@ module Ruby2D
     def color=(c)
       @color = Color.from(c)
       update_color(@color)
-    end
-    
-    def add
-      if Module.const_defined? :DSL
-        Application.add(self)
-      end
-    end
-    
-    def remove
-      if Module.const_defined? :DSL
-        Application.remove(self)
-      end
     end
     
     private

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -1,0 +1,15 @@
+module Ruby2D
+  module Renderable
+    def add
+      if Module.const_defined? :DSL
+        Application.add(self)
+      end
+    end
+    
+    def remove
+      if Module.const_defined? :DSL
+        Application.remove(self)
+      end
+    end
+  end
+end

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -2,6 +2,7 @@
 
 module Ruby2D
   class Text
+    include Renderable
     
     attr_accessor :x, :y, :data
     attr_reader :text, :size, :font, :color
@@ -29,18 +30,6 @@ module Ruby2D
     
     def color=(c)
       @color = Color.new(c)
-    end
-    
-    def add
-      if Module.const_defined? :DSL
-        Application.add(self)
-      end
-    end
-    
-    def remove
-      if Module.const_defined? :DSL
-        Application.remove(self)
-      end
     end
     
     private

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -2,6 +2,7 @@
 
 module Ruby2D
   class Triangle
+    include Renderable
     
     attr_accessor :x1, :y1, :c1,
                   :x2, :y2, :c2,
@@ -21,18 +22,6 @@ module Ruby2D
     def color=(c)
       @color = Color.from(c)
       update_color(@color)
-    end
-    
-    def add
-      if Module.const_defined? :DSL
-        Application.add(self)
-      end
-    end
-    
-    def remove
-      if Module.const_defined? :DSL
-        Application.remove(self)
-      end
     end
     
     private


### PR DESCRIPTION
Please treat this PR as a question, not a suggestion. What do you think about:
  - Introducing Renderable module to reuse #add and #remove logic, which is common across all renderable objects ?
  - introducing #rerender method to all renderable objects?

First just seems like a clean approach, second I am doing all the time, and it simply seems like something that should be native.