### PR TITLE
Introduce z-order mechanism

### DIFF
--- a/lib/ruby2d/application.rb
+++ b/lib/ruby2d/application.rb
@@ -35,6 +35,10 @@ module Ruby2D::Application
     def clear
       @@window.clear
     end
+
+    def z_sort
+      @@window.dirty = true
+    end
     
     def update(&proc)
       @@window.update(&proc)

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -5,9 +5,9 @@ module Ruby2D
     include Renderable
 
     attr_accessor :x, :y, :width, :height, :data
-    attr_reader :path, :color
+    attr_reader :path, :color, :z
     
-    def initialize(x, y, path)
+    def initialize(x, y, path, z=0)
       
       # TODO: Check if file exists
       #   `File.exists?` is not available in MRuby
@@ -17,7 +17,7 @@ module Ruby2D
       #     end
       
       @type_id = 3
-      @x, @y, @path = x, y, path
+      @x, @y, @z, @path = x, y, z, path
       @color = Color.new([1, 1, 1, 1])
       init(path)
       add
@@ -26,5 +26,11 @@ module Ruby2D
     def color=(c)
       @color = Color.new(c)
     end
+
+    def z=(z)
+      @z = z
+      Application.z_sort
+    end
+        
   end
 end

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -13,11 +13,11 @@ module Ruby2D
                   :x3, :y3, :c3,
                   :x4, :y4, :c4
     
-    attr_reader :color
+    attr_reader :color, :z
     
-    def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white')
+    def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white', z=0)
       @type_id = 2
-      @x1, @y1, @x2, @y2, @x3, @y3, @x4, @y4 = x1, y1, x2, y2, x3, y3, x4, y4
+      @x1, @y1, @x2, @y2, @x3, @y3, @x4, @y4, @z = x1, y1, x2, y2, x3, y3, x4, y4, z
       
       self.color = c
       add
@@ -26,6 +26,11 @@ module Ruby2D
     def color=(c)
       @color = Color.from(c)
       update_color(@color)
+    end
+
+    def z=(z)
+      @z = z
+      Application.z_sort
     end
     
     private

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -5,9 +5,9 @@ module Ruby2D
     
     attr_reader :x, :y, :width, :height
     
-    def initialize(x=0, y=0, w=200, h=100, c='white')
+    def initialize(x=0, y=0, w=200, h=100, c='white', z=0)
       @type_id = 2
-      @x, @y, @width, @height = x, y, w, h
+      @x, @y, @z, @width, @height = x, y, z, w, h
       update_coords(x, y, w, h)
 
       self.color = c

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -4,15 +4,16 @@ module Ruby2D
   class Sprite
     
     attr_accessor :x, :y, :clip_x, :clip_y, :clip_w, :clip_h, :data
+    attr_reader :z
     
-    def initialize(x, y, path)
+    def initialize(x, y, path, z=0)
       
       # unless File.exists? path
       #   raise Error, "Cannot find image file `#{path}`"
       # end
       
       @type_id = 4
-      @x, @y, @path = x, y, path
+      @x, @y, @z, @path = x, y, z, path
       @clip_x, @clip_y, @clip_w, @clip_h = 0, 0, 0, 0
       @default = nil
       @animations = {}
@@ -61,6 +62,11 @@ module Ruby2D
         Application.remove(self)
       end
     end
+
+    def z=(z)
+      @z = z
+      Application.z_sort
+    end    
     
     private
     

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -5,9 +5,9 @@ module Ruby2D
     
     attr_reader :size
     
-    def initialize(x=0, y=0, s=100, c='white')
+    def initialize(x=0, y=0, s=100, c='white', z=0)
       @type_id = 2
-      @x, @y = x, y
+      @x, @y, @z = x, y, z
       @width = @height = @size = s
       update_coords(x, y, s, s)
 

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -5,9 +5,9 @@ module Ruby2D
     include Renderable
     
     attr_accessor :x, :y, :data
-    attr_reader :text, :size, :width, :height, :font, :color
+    attr_reader :text, :size, :width, :height, :font, :color, :z
     
-    def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c="white")
+    def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c="white", z=0)
       
       # if File.exists? font
         @font = font
@@ -16,7 +16,7 @@ module Ruby2D
       # end
       
       @type_id = 5
-      @x, @y, @size = x, y, size
+      @x, @y, @z, @size = x, y, z, size
       @text = text.to_s
       self.color = c
       init
@@ -30,6 +30,11 @@ module Ruby2D
     
     def color=(c)
       @color = Color.new(c)
+    end
+
+    def z=(z)
+      @z = z
+      Application.z_sort
     end
     
     private

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -7,13 +7,14 @@ module Ruby2D
     attr_accessor :x1, :y1, :c1,
                   :x2, :y2, :c2,
                   :x3, :y3, :c3
-    attr_reader :color, :type_id
+    attr_reader :color, :type_id, :z
     
-    def initialize(x1=50, y1=0, x2=100, y2=100, x3=0, y3=100, c='white')
+    def initialize(x1=50, y1=0, x2=100, y2=100, x3=0, y3=100, c='white', z=0)
       @type_id = 1
       @x1, @y1 = x1, y1
       @x2, @y2 = x2, y2
       @x3, @y3 = x3, y3
+      @z = z
 
       self.color = c
       add
@@ -22,6 +23,11 @@ module Ruby2D
     def color=(c)
       @color = Color.from(c)
       update_color(@color)
+    end
+
+    def z=(z)
+      @z = z
+      Application.z_sort
     end
     
     private

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -4,7 +4,7 @@ module Ruby2D
   class Window
     
     attr_reader :objects
-    attr_accessor :mouse_x, :mouse_y, :frames, :fps
+    attr_accessor :mouse_x, :mouse_y, :frames, :fps, :dirty
     
     def initialize(args = {})
       @title      = args[:title]  || "Ruby 2D"
@@ -27,6 +27,7 @@ module Ruby2D
       @on_controller_proc = Proc.new {}
       @update_proc        = Proc.new {}
       @diagnostics        = false
+      @dirty              = false
     end
     
     def get(sym)
@@ -89,6 +90,11 @@ module Ruby2D
       else
         false
       end
+    end
+
+    def z_sort
+      @objects = @objects.sort_by {|o| o.z }
+      @dirty = false
     end
     
     def clear
@@ -182,6 +188,7 @@ module Ruby2D
     
     def update_callback
       @update_proc.call
+      z_sort if @dirty
     end
     
     private


### PR DESCRIPTION
This PR attempts to:

- Introduce a mechanism to enable ordering of rendered objects along the z-axis (front to back to the user, lower ints at the back and higher at the front)
- Try and keep costly calls to a minimum (as sorting a large array of @objects can result in fps drops)

This helps us because:

Currently, if a user wants to render an object above or below another object, then they would have to make sure that they arrange their code in a way that satisfies the default render order, call remove/add a lot or attempt to inject an object at a specific location in the @objects array somehow. This PR essentially gives us a way of specifying ‘layers’ at initialisation and changing them on the fly (via obj.z=) without add/remove.

What it doesn’t do:

- Is provide mechanisms for keeping @objects.size low, though it’s perhaps pertinent to highlight this anyway

The PR implements the following:

- Any renderable object gains a ‘z’ attribute
- Window/Application gains a sorting method that sorts @objects by their ‘z’ attribute
- Whenever the ‘z’ attribute gets set, it triggers the setting of a ‘dirty’ flag notifying Window that it should sort the @objects before the next render occurs (note, the flag is used to avoid lots of calls to the sort method but does not completely avoid that scenario)

What works:

- MRI (OSX)
- Native/mruby building (OSX)
- Web

What doesn’t work:

- Not found anything, yet.

What I would say however, is that the sort itself could be handled on the C-side as I suspect it could be quicker there. This simply provides us with options at this early stage in development.