### PR TITLE
allow events unbinding

### DIFF
--- a/lib/ruby2d/application.rb
+++ b/lib/ruby2d/application.rb
@@ -16,12 +16,8 @@ module Ruby2D::Application
       @@window.on(event, &proc)
     end
     
-    def on_key(&proc)
-      @@window.on_key(&proc)
-    end
-    
-    def on_controller(&proc)
-      @@window.on_controller(&proc)
+    def off(event_descriptor)
+      @@window.off(event_descriptor)
     end
     
     def add(o)

--- a/lib/ruby2d/dsl.rb
+++ b/lib/ruby2d/dsl.rb
@@ -13,12 +13,8 @@ module Ruby2D::DSL
     Application.on(event, &proc)
   end
   
-  def on_key(&proc)
-    Application.on_key(&proc)
-  end
-  
-  def on_controller(&proc)
-    Application.on_controller(&proc)
+  def off(event_descriptor)
+    Application.off(event_descriptor)
   end
   
   def update(&proc)

--- a/test/events_spec.rb
+++ b/test/events_spec.rb
@@ -1,0 +1,126 @@
+require 'ruby2d'
+
+RSpec.describe Window do
+  [:key, :key_down, :key_held, :key_up].each do |key_event_type|
+    describe "on #{key_event_type}" do
+      it "allows binding of event" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        callback_event_name = key_event_type.to_s.gsub("key_", "").to_sym
+        window.key_callback(callback_event_name, "example_key")
+        expect(value).to eq 1
+      end
+
+      it "allows binding of multiple events" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        window.on(key_event_type) do
+          value += 2
+        end
+        callback_event_name = key_event_type.to_s.gsub("key_", "").to_sym
+        window.key_callback(callback_event_name, "example_key")
+        expect(value).to eq 3
+      end
+
+      it "returns value, which can be used to unbind event" do
+        window = Ruby2D::Window.new
+        value = 0
+        event_descriptor = window.on(key_event_type) do
+          value += 1
+        end
+        window.off(event_descriptor)
+        callback_event_name = key_event_type.to_s.gsub("key_", "").to_sym
+        window.key_callback(callback_event_name, "example_key")
+        expect(value).to eq 0
+      end
+    end
+  end
+
+  [:mouse, :mouse_up, :mouse_down, :mouse_scroll, :mouse_move].each do |key_event_type|
+    describe "on #{key_event_type}" do
+      it "allows binding of event" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        callback_event_name = key_event_type.to_s.gsub("mouse_", "").to_sym
+        window.mouse_callback(callback_event_name, nil, nil, 0, 0, 0, 0)
+        expect(value).to eq 1
+      end
+
+      it "allows binding of multiple events" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        window.on(key_event_type) do
+          value += 2
+        end
+        callback_event_name = key_event_type.to_s.gsub("mouse_", "").to_sym
+        window.mouse_callback(callback_event_name, nil, nil, 0, 0, 0, 0)
+        expect(value).to eq 3
+      end
+
+      it "returns value, which can be used to unbind event" do
+        window = Ruby2D::Window.new
+        value = 0
+        event_descriptor = window.on(key_event_type) do
+          value += 1
+        end
+        window.off(event_descriptor)
+        callback_event_name = key_event_type.to_s.gsub("mouse_", "").to_sym
+        window.mouse_callback(callback_event_name, nil, nil, 0, 0, 0, 0)
+        expect(value).to eq 0
+      end
+    end
+  end
+
+  [:controller, :controller_axis, :controller_button_up, :controller_button_down].each do |key_event_type|
+    describe "on #{key_event_type}" do
+      it "allows binding of event" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        callback_event_name = key_event_type.to_s.gsub("controller_", "").to_sym
+        window.controller_callback(nil, callback_event_name, nil, nil, nil)
+        expect(value).to eq 1
+      end
+
+      it "allows binding of multiple events" do
+        window = Ruby2D::Window.new
+        value = 0
+        window.on(key_event_type) do
+          value += 1
+        end
+        window.on(key_event_type) do
+          value += 2
+        end
+        callback_event_name = key_event_type.to_s.gsub("controller_", "").to_sym
+        window.controller_callback(nil, callback_event_name, nil, nil, nil)
+        expect(value).to eq 3
+      end
+
+      it "returns value, which can be used to unbind event" do
+        window = Ruby2D::Window.new
+        value = 0
+        event_descriptor = window.on(key_event_type) do
+          value += 1
+        end
+        window.off(event_descriptor)
+        callback_event_name = key_event_type.to_s.gsub("controller_", "").to_sym
+        window.controller_callback(nil, callback_event_name, nil, nil, nil)
+        expect(value).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
As always, please treat this as a feature suggestion, and an invitation to discussion.

I would like to begin by apologising of multiple lines of removed whitespace. If needed, I can update the PR so that those changes would not be visible, although I remember once that you corrected me on this.

So, to business: This pull request introduces ability to unbind events.

Public API is not changed at all, so if somebody is not interested in ability to remove events, he doesn't have to change a single line of code.

New API, an extension of the current one works as follows: `Window#on` method returns an object, that can be then passed to `Window#off` method. Plain and simple. Similiar idea is used in javascripts `#addEventListener` and `#removeEventListener`

Under the hood, events are no longer stored in an array, but rather in a hash, keyed by an id, generated on event binding.
This change barely influencs events calling code, as it simply has to change from `events_collection.each do |event|` to `events_collection.each do |id, event|`.

I am using a string, starting with the letter "a", and in each turn replacing it with it's successor. I am using one id generator for all events, because it makes the implementation simpler. Using separate one for each events collection is possible, but I would argue, that it's unnecessary.

From code point of view, I also did the following:
  - introduced `#events_store` method, since it's now used in 2 places, it make sense to me.
  - Removed `DSL#on_key`, `DSL#on_controller`, `Application#on_key`, `Application#on_controller`. If I understand correctly, those are remnants from the past, not cleaned up properly to date. I was thinking about preparing separate PR for this, but I decided to include it here in the end.
  - made sure that :controller_button_down and :controller_button_up events are being handled properly. There were containers for those events, but `#on` only responded to `:controller_button` event. If I misunderstood the logic, please correct me.

Also, for each event type, I added test to:
  - add and call one event handler
  - add and call multiple event handlers
  - remove previously added event handler.

Since there was no tests for this at all, I assumed it will come in handy. (And it did, I found those controller buttons events bug; ))

And, finally, why?

I want to implement menu that would work sort of like https://getbootstrap.com/components/#dropdowns. This seems to be a reasonable way to make things work well.

Sorry for making it a big read, I just like laying it all down.