### PR TITLE
another take on z-index

### DIFF
--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -7,7 +7,7 @@ module Ruby2D
     attr_accessor :x, :y, :width, :height, :data
     attr_reader :path, :color
     
-    def initialize(x, y, path)
+    def initialize(x, y, path, z=0)
       
       unless RUBY_ENGINE == 'opal'
         unless File.exists? path
@@ -17,6 +17,7 @@ module Ruby2D
       
       @type_id = 3
       @x, @y, @path = x, y, path
+      @z = z
       @color = Color.new([1, 1, 1, 1])
       init(path)
       add

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -15,9 +15,10 @@ module Ruby2D
     
     attr_reader :color
     
-    def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white')
+    def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white', z=0)
       @type_id = 2
       @x1, @y1, @x2, @y2, @x3, @y3, @x4, @y4 = x1, y1, x2, y2, x3, y3, x4, y4
+      @z = z
       
       self.color = c
       add

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -5,9 +5,10 @@ module Ruby2D
     
     attr_reader :x, :y, :width, :height
     
-    def initialize(x=0, y=0, w=200, h=100, c='white')
+    def initialize(x=0, y=0, w=200, h=100, c='white', z=0)
       @type_id = 2
       @x, @y, @width, @height = x, y, w, h
+      @z = z
       update_coords(x, y, w, h)
 
       self.color = c

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -1,5 +1,13 @@
 module Ruby2D
   module Renderable
+    attr_reader :z
+
+    def z=(z)
+      remove
+      @z = z
+      add
+    end
+
     def add
       if Module.const_defined? :DSL
         Application.add(self)

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -4,9 +4,10 @@ module Ruby2D
   class Sprite
     
     attr_accessor :x, :y, :clip_x, :clip_y, :clip_w, :clip_h, :data
-    
-    def initialize(x, y, path)
-      
+    attr_reader :z
+
+    def initialize(x, y, path, z=0)
+
       # unless File.exists? path
       #   raise Error, "Cannot find image file `#{path}`"
       # end
@@ -19,7 +20,8 @@ module Ruby2D
       @current_animation = nil
       @current_frame = 0
       @current_frame_time = 0
-      
+      @z = z
+
       init(path)
       if Module.const_defined? :DSL
         Application.add(self)

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -5,10 +5,11 @@ module Ruby2D
     
     attr_reader :size
     
-    def initialize(x=0, y=0, s=100, c='white')
+    def initialize(x=0, y=0, s=100, c='white', z=0)
       @type_id = 2
       @x, @y = x, y
       @width = @height = @size = s
+      @z = z
       update_coords(x, y, s, s)
 
       self.color = c

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -7,7 +7,7 @@ module Ruby2D
     attr_accessor :x, :y, :data
     attr_reader :text, :size, :width, :height, :font, :color
     
-    def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c="white")
+    def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c='white', z=0)
       
       # if File.exists? font
         @font = font
@@ -17,6 +17,7 @@ module Ruby2D
       
       @type_id = 5
       @x, @y, @size = x, y, size
+      @z = z
       @text = text.to_s
       self.color = c
       init

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -9,11 +9,12 @@ module Ruby2D
                   :x3, :y3, :c3
     attr_reader :color, :type_id
     
-    def initialize(x1=50, y1=0, x2=100, y2=100, x3=0, y3=100, c='white')
+    def initialize(x1=50, y1=0, x2=100, y2=100, x3=0, y3=100, c='white', z=0)
       @type_id = 1
       @x1, @y1 = x1, y1
       @x2, @y2 = x2, y2
       @x3, @y3 = x3, y3
+      @z = z
 
       self.color = c
       add

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -230,7 +230,14 @@ module Ruby2D
     
     def add_object(o)
       if !@objects.include?(o)
-        @objects.push(o)
+        index = @objects.index do |object|
+          object.z > o.z
+        end
+        if index
+          @objects.insert(index, o)
+        else
+          @objects.push(o)
+        end
         true
       else
         false

--- a/test/z_index.rb
+++ b/test/z_index.rb
@@ -1,0 +1,46 @@
+require 'ruby2d'
+
+set title: "Hello z-index"
+set width: 500, height: 500
+
+class ZIndexGenerator
+  def initialize
+    @z_index = 0
+  end
+
+  def get
+    @z_index += 1
+    @z_index
+  end
+end
+
+@z_index_generator = ZIndexGenerator.new
+
+class Ruby2D::Square
+  def contains?(x, y)
+    x > @x and x < @x + @width and y > @y and y < @y + @height
+  end
+end
+
+objects = []
+objects << Square.new(50, 50, 200, "red",   @z_index_generator.get)
+objects << Square.new(100, 50, 200, "blue", @z_index_generator.get)
+
+on :mouse_down do |event|
+  x = event.x
+  y = event.y
+  case event.button
+  when :left
+    # Find square that you clicked, and set it's z-index to highest one in set
+    objects.sort!{|a, b| -a.z <=> -b.z }
+    first_object = objects.find do |object|
+      object.contains?(x, y)
+    end
+    first_object.z = @z_index_generator.get if first_object
+  when :right
+    # Add new square with z-index of zero, with the middle at mouse position
+    objects << Square.new(x - 100, y - 100, 200, "random", -objects.count)
+  end
+end
+
+show


### PR DESCRIPTION
Since we haven't heard from @jamiepirie for 3 weeks now, and I'm also interested in z-index feature, I decided to give it a go myself.

First of all, this PR maintains 100% backwards compatibility with master. 
Second of all, I added a `z` value to every renderable object. It is used when adding that object to a list of renderables to make sure that it will be rendered in correct order.

I created z-index test file to present the behavior. In that script, left click moves the square you clicked to the top, and right-click adds new square at the bottom. 

Changing z-index works by removing the renderable from objects, updating the z-index and reinserting it at proper place.

I prepared 2 benchmarks. First one goes by this code:

```
require 'ruby2d'

set title: "Ruby 2D — Adding squares benchmark", width: 400, height: 300

squares_count = 1000
mean_size = 40
results = []

update do
  time = Time.now
  squares_count.times do
    Square.new(rand(400), rand(400), 30, "random")
  end
  results << Time.now - time
  if results.size > mean_size
    results.shift
  end
  if results.size == mean_size
    p "adding #{squares_count} squares: #{results.inject(&:+) / mean_size}"
  end
  clear
end
show
```

What it does is in loop, creates and adds 1000 squares to the renderables. The purpose of this is to make sure that there will be no performance regression with the new code. The results:

MASTER:
MRI:    "adding 1000 squares: 0.012"
NATIVE: "adding 1000 squares: 0.276"
WEB:    "adding 1000 squares: 0.062"

THIS BRANCH:
MRI:    "adding 1000 squares: 0.0115"
NATIVE: "adding 1000 squares: 0.2703"
WEB:    "adding 1000 squares: 0.0426"

Those are example values taken from the list of rendered results. Those results differ over time in both cases, so I would make a case that the performance characteristics doesn't change.

Second benchmark I wanted to do was to benchmark how fast I can add 1000 objects and have them rendered in reverse order. This would be a worst case scenario, but not too far from what I'm dealing with. Consider screen from my game: 
![screen](https://cloud.githubusercontent.com/assets/1272828/25445958/299b5a2c-2ab0-11e7-864e-ee3e84a7bfd6.png)

Note there is multiple kinds of objects visible: 2 separate menus, each with it's own content, map with characters, trees, prezented zones etc. 
In code, I want to deal with those based on the logic associated with them, not based on order in which I want them to be rendered.

Currently I am forced, after initialisation of entire game data, to go through all visible content, and rerender (remove and add) them to force them to be in expected order. Then, through the runtime, I need to do this often, and often it's not possible without killing performance.

So, to test this I prepared 2 benchmarks, separate from master and for branch. Master:

```
require 'ruby2d'

set title: "Ruby 2D — Adding squares benchmark", width: 400, height: 300

squares_count = 1000
mean_size = 40
results = []

update do
  time = Time.now
  squares = []
  squares_count.times do
    squares << Square.new(rand(400), rand(400), 30, "random")
  end

  squares.reverse_each do |square|
    square.remove
    square.add
  end

  results << Time.now - time
  if results.size > mean_size
    results.shift
  end
  if results.size == mean_size
    p "adding #{squares_count} squares: #{results.inject(&:+) / mean_size}"
  end
  clear
end
show
```

This benchmark in loop creates a 1000 squares, and rerenders them in reverse order. 
Results:

MRI:    "adding 1000 squares: 0.0315"
NATIVE: "adding 1000 squares: 0.9808"
WEB:    "adding 1000 squares: 0.1123"

Benchmark for this branch looks like this:

```

require 'ruby2d'

set title: "Ruby 2D — Adding squares benchmark", width: 400, height: 300

squares_count = 1000
mean_size = 40
results = []

update do
  time = Time.now
  squares = []
  squares_count.times do |i|
    squares << Square.new(rand(400), rand(400), 30, "random", squares_count - i)
  end

  results << Time.now - time
  if results.size > mean_size
    results.shift
  end
  if results.size == mean_size
    p "adding #{squares_count} squares: #{results.inject(&:+) / mean_size}"
  end
  clear
end
show
```

The difference is, instead of rerendering already created objects, we create them with specific z-index in mind and leave them there. Results:

MRI:    "adding 1000 squares: 0.012"
NATIVE: "adding 1000 squares: 0.296"
WEB:    "adding 1000 squares: 0.044"

Across platforms new implementation performs from 2.55 to 3.3 times faster than the old solution.

What do you think?