### PR TITLE
Opacity improvements

### DIFF
--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -15,7 +15,9 @@ module Ruby2D
       def length
         @colors.length
       end
-
+      
+      def opacity; @colors[0].opacity end
+      
       def opacity=(opacity)
         @colors.each do |color|
           color.opacity = opacity
@@ -95,7 +97,9 @@ module Ruby2D
         Color.new(input)
       end
     end
-
+    
+    def opacity; @a end
+    
     def opacity=(opacity)
       @a = opacity
     end

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -11,5 +11,13 @@ module Ruby2D
         Application.remove(self)
       end
     end
+    
+    def opacity
+      self.color.opacity
+    end
+    
+    def opacity=(val)
+      self.color.opacity = val
+    end
   end
 end

--- a/test/color_spec.rb
+++ b/test/color_spec.rb
@@ -32,4 +32,15 @@ RSpec.describe Ruby2D::Color do
     end
   end
   
+  describe '#opacity' do
+    it 'sets and returns the opacity' do
+      s1 = Square.new
+      s1.opacity = 0.5
+      s2 = Square.new(0, 0, 0, ['red', 'green', 'blue', 'yellow'])
+      s2.opacity = 0.7
+      expect(s1.opacity).to eq 0.5
+      expect(s2.opacity).to eq 0.7
+    end
+  end
+  
 end


### PR DESCRIPTION
Adds opacity attribute reader for `Ruby2D::Color` and
`Ruby2D::Color::Set`. Adds `opacity/=` method to renderable objects, a
shortcut for `obj.color.opacity/=`.