### PR TITLE
Store image width and height on creation

### DIFF
--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -176,7 +176,14 @@ function render() {
 module Ruby2D
   class Image
     def init(path)
-      `#{self}.data = S2D.CreateImage(path);`
+      `#{self}.data = S2D.CreateImage(path, function() {
+        if (#{@width} == Opal.nil) {
+          #{@width} = #{self}.data.width;
+        }
+        if (#{@height} == Opal.nil) {
+          #{@height} = #{self}.data.height;
+        }
+      });`
     end
   end
   

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -161,6 +161,8 @@ static R_VAL ruby2d_image_init(R_VAL self, R_VAL path) {
   sprintf(S2D_msg, "Init image: %s", RSTRING_PTR(path));
   S2D_Log(S2D_msg, S2D_INFO);
   S2D_Image *img = S2D_CreateImage(RSTRING_PTR(path));
+  r_iv_set(self, "@width", INT2NUM(img->width));
+  r_iv_set(self, "@height", INT2NUM(img->height));
   r_iv_set(self, "@data", r_data_wrap_struct(image, img));
   return R_NIL;
 }


### PR DESCRIPTION
Since images are loaded asynchronously on the web and the width and height might have already been set by the user, set them only if they are nil.