### PR TITLE
Call extensions explicitly

### DIFF
--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -186,7 +186,7 @@ function render() {
 
 module Ruby2D
   class Image
-    def init(path)
+    def ext_image_init(path)
       `#{self}.data = S2D.CreateImage(path, function() {
         if (#{@width} == Opal.nil) {
           #{@width} = #{self}.data.width;
@@ -199,13 +199,13 @@ module Ruby2D
   end
   
   class Sprite
-    def init(path)
+    def ext_sprite_init(path)
       `#{self}.data = S2D.CreateSprite(path);`
     end
   end
   
   class Text
-    def init
+    def ext_text_init
       `#{self}.data = S2D.CreateText(#{self}.font, #{self}.text, #{self}.size);`
       @width  = `#{self}.data.width;`
       @height = `#{self}.data.height;`
@@ -219,43 +219,43 @@ module Ruby2D
   end
   
   class Sound
-    def init(path)
+    def ext_sound_init(path)
       `#{self}.data = S2D.CreateSound(path);`
     end
     
-    def play
+    def ext_sound_play
       `S2D.PlaySound(#{self}.data);`
     end
   end
   
   class Music
-    def init(path)
+    def ext_music_init(path)
       `#{self}.data = S2D.CreateMusic(path);`
     end
     
-    def play
+    def ext_music_play
       `S2D.PlayMusic(#{self}.data, #{self}.loop);`
     end
     
-    def pause
+    def ext_music_pause
       `S2D.PauseMusic();`
     end
     
-    def resume
+    def ext_music_resume
       `S2D.ResumeMusic();`
     end
     
-    def stop
+    def ext_music_stop
       `S2D.StopMusic();`
     end
     
-    def fadeout(ms)
+    def ext_music_fadeout(ms)
       `S2D.FadeOutMusic(ms);`
     end
   end
   
   class Window
-    def show
+    def ext_window_show
       $R2D_WINDOW = self
       
       `

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -260,11 +260,11 @@ static R_VAL ruby2d_text_init(R_VAL self) {
  * Ruby2D::Text#ext_text_set
  */
 #if MRUBY
-static R_VAL ruby2d_ext_text_set(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_text_set(mrb_state* mrb, R_VAL self) {
   mrb_value text;
   mrb_get_args(mrb, "o", &text);
 #else
-static R_VAL ruby2d_ext_text_set(R_VAL self, R_VAL text) {
+static R_VAL ruby2d_text_set(R_VAL self, R_VAL text) {
 #endif
   S2D_Text *txt;
   r_data_get_struct(self, "@data", &text_data_type, S2D_Text, txt);
@@ -863,61 +863,61 @@ void Init_ruby2d() {
   R_CLASS ruby2d_image_class = r_define_class(ruby2d_module, "Image");
   
   // Ruby2D::Image#init
-  r_define_method(ruby2d_image_class, "init", ruby2d_image_init, r_args_req(1));
+  r_define_method(ruby2d_image_class, "ext_image_init", ruby2d_image_init, r_args_req(1));
   
   // Ruby2D::Sprite
   R_CLASS ruby2d_sprite_class = r_define_class(ruby2d_module, "Sprite");
   
   // Ruby2D::Sprite#init
-  r_define_method(ruby2d_sprite_class, "init", ruby2d_sprite_init, r_args_req(1));
+  r_define_method(ruby2d_sprite_class, "ext_sprite_init", ruby2d_sprite_init, r_args_req(1));
   
   // Ruby2D::Text
   R_CLASS ruby2d_text_class = r_define_class(ruby2d_module, "Text");
   
   // Ruby2D::Text#init
-  r_define_method(ruby2d_text_class, "init", ruby2d_text_init, r_args_none);
+  r_define_method(ruby2d_text_class, "ext_text_init", ruby2d_text_init, r_args_none);
   
   // Ruby2D::Text#ext_text_set
-  r_define_method(ruby2d_text_class, "ext_text_set", ruby2d_ext_text_set, r_args_req(1));
+  r_define_method(ruby2d_text_class, "ext_text_set", ruby2d_text_set, r_args_req(1));
   
   // Ruby2D::Sound
   R_CLASS ruby2d_sound_class = r_define_class(ruby2d_module, "Sound");
   
   // Ruby2D::Sound#init
-  r_define_method(ruby2d_sound_class, "init", ruby2d_sound_init, r_args_req(1));
+  r_define_method(ruby2d_sound_class, "ext_sound_init", ruby2d_sound_init, r_args_req(1));
   
   // Ruby2D::Sound#play
-  r_define_method(ruby2d_sound_class, "play", ruby2d_sound_play, r_args_none);
+  r_define_method(ruby2d_sound_class, "ext_sound_play", ruby2d_sound_play, r_args_none);
   
   // Ruby2D::Music
   R_CLASS ruby2d_music_class = r_define_class(ruby2d_module, "Music");
   
   // Ruby2D::Music#init
-  r_define_method(ruby2d_music_class, "init", ruby2d_music_init, r_args_req(1));
+  r_define_method(ruby2d_music_class, "ext_music_init", ruby2d_music_init, r_args_req(1));
   
   // Ruby2D::Music#play
-  r_define_method(ruby2d_music_class, "play", ruby2d_music_play, r_args_none);
+  r_define_method(ruby2d_music_class, "ext_music_play", ruby2d_music_play, r_args_none);
   
   // Ruby2D::Music#pause
-  r_define_method(ruby2d_music_class, "pause", ruby2d_music_pause, r_args_none);
+  r_define_method(ruby2d_music_class, "ext_music_pause", ruby2d_music_pause, r_args_none);
   
   // Ruby2D::Music#resume
-  r_define_method(ruby2d_music_class, "resume", ruby2d_music_resume, r_args_none);
+  r_define_method(ruby2d_music_class, "ext_music_resume", ruby2d_music_resume, r_args_none);
   
   // Ruby2D::Music#stop
-  r_define_method(ruby2d_music_class, "stop", ruby2d_music_stop, r_args_none);
+  r_define_method(ruby2d_music_class, "ext_music_stop", ruby2d_music_stop, r_args_none);
   
   // Ruby2D::Music#fadeout
-  r_define_method(ruby2d_music_class, "fadeout", ruby2d_music_fadeout, r_args_req(1));
+  r_define_method(ruby2d_music_class, "ext_music_fadeout", ruby2d_music_fadeout, r_args_req(1));
   
   // Ruby2D::Window
   R_CLASS ruby2d_window_class = r_define_class(ruby2d_module, "Window");
   
   // Ruby2D::Window#show
-  r_define_method(ruby2d_window_class, "show", ruby2d_show, r_args_none);
+  r_define_method(ruby2d_window_class, "ext_window_show", ruby2d_show, r_args_none);
   
   // Ruby2D::Window#close
-  r_define_method(ruby2d_window_class, "close", ruby2d_close, r_args_none);
+  r_define_method(ruby2d_window_class, "ext_window_close", ruby2d_close, r_args_none);
   
 #if MRUBY
   // Load the Ruby 2D app

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -19,7 +19,7 @@ module Ruby2D
       @x, @y, @path = x, y, path
       @z = z
       @color = Color.new([1, 1, 1, 1])
-      init(path)
+      ext_image_init(path)
       add
     end
     

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -14,10 +14,29 @@ module Ruby2D
         end
       end
       
-      init(path)
       @path = path
       @loop = false
+      ext_music_init(path)
     end
     
+    def play
+      ext_music_play
+    end
+    
+    def pause
+      ext_music_pause
+    end
+    
+    def resume
+      ext_music_resume
+    end
+    
+    def stop
+      ext_music_stop
+    end
+    
+    def fadeout(ms)
+      ext_music_fadeout(ms)
+    end
   end
 end

--- a/lib/ruby2d/sound.rb
+++ b/lib/ruby2d/sound.rb
@@ -14,8 +14,12 @@ module Ruby2D
         end
       end
       
-      init(path)
       @path = path
+      ext_sound_init(path)
+    end
+    
+    def play
+      ext_sound_play
     end
     
   end

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -22,7 +22,7 @@ module Ruby2D
       @current_frame_time = 0
       @z = z
 
-      init(path)
+      ext_sprite_init(path)
       if Module.const_defined? :DSL
         Application.add(self)
       end

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -20,7 +20,7 @@ module Ruby2D
       @z = z
       @text = text.to_s
       self.color = c
-      init
+      ext_text_init
       add
     end
     

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -224,6 +224,14 @@ module Ruby2D
       @update_proc.call
     end
     
+    def show
+      ext_window_show
+    end
+    
+    def close
+      ext_window_close
+    end
+    
     private
     
     def add_object(o)


### PR DESCRIPTION
No more are extension methods magically added to Ruby classes. Now, classes must explicitly call web and native extensions using methods with the naming convention `ext_<class>_<method>`.