### PR TITLE
Renderable contains

### DIFF
--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -26,5 +26,9 @@ module Ruby2D
     def color=(c)
       @color = Color.new(c)
     end
+
+    def contains?(x, y)
+      @x < x and @x + @width > x and @y < y and @y + @height > y
+    end
   end
 end

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -19,7 +19,24 @@ module Ruby2D
       update_color(@color)
     end
 
+    def length
+      points_distance(@x1, @y1, @x2, @y2)
+    end
+
+    # Line contains a point if the point is closer than the length of line from both ends
+    # and if the distance from point to line is smaller than half of the width.
+    # Check https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line for reference
+    def contains?(x, y)
+      points_distance(x1, y1, x, y) < length and
+      points_distance(x2, y2, x, y) < length and
+      (((@y2 - @y1) * x - (@x2 - @x1) * y + @x2 * @y1 - @y2 * @x1).abs / length) < 0.5 * @width
+    end
+
     private
+
+    def points_distance(x1, y1, x2, y2)
+      Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
+    end
 
     def update_color(c)
       if c.is_a? Color::Set

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -29,7 +29,25 @@ module Ruby2D
       update_color(@color)
     end
 
+    # The logic is the same as for a triangle
+    # See triangle.rb for reference
+    def contains?(x, y)
+      self_area = triangle_area(@x1, @y1, @x2, @y2, @x3, @y3) +
+                  triangle_area(@x1, @y1, @x3, @y3, @x4, @y4)
+
+      questioned_area = triangle_area(@x1, @y1, @x2, @y2, x, y) +
+                        triangle_area(@x2, @y2, @x3, @y3, x, y) +
+                        triangle_area(@x3, @y3, @x4, @y4, x, y) +
+                        triangle_area(@x4, @y4, @x1, @y1, x, y)
+
+      questioned_area <= self_area
+    end
+
     private
+
+    def triangle_area(x1, y1, x2, y2, x3, y3)
+      (x1*y2 + x2*y3 + x3*y1 - x3*y2 - x1*y3 - x2*y1).abs / 2
+    end
 
     def update_color(c)
       if c.is_a? Color::Set

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -39,6 +39,10 @@ module Ruby2D
       update_coords(@x, @y, @width, h)
     end
 
+    def contains?(x, y)
+      @x < x and @x + @width > x and @y < y and @y + @height > y
+    end
+
     private
 
     def update_coords(x, y, w, h)

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -27,5 +27,9 @@ module Ruby2D
     def opacity=(val)
       self.color.opacity = val
     end
+
+    def contains?(x, y)
+      raise "Not implemented yet"
+    end
   end
 end

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -33,6 +33,10 @@ module Ruby2D
       @color = Color.new(c)
     end
 
+    def contains?(x, y)
+      @x < x and @x + @width > x and @y < y and @y + @height > y
+    end
+
     private
 
     def resolve_path(font)

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -25,7 +25,24 @@ module Ruby2D
       update_color(@color)
     end
 
+    # Point is inside a triangle if
+    # the area of 3 triangles, constructed from triangle sides and that point
+    # is equal to the area of triangle.
+    def contains?(x, y)
+      self_area = triangle_area(@x1, @y1, @x2, @y2, @x3, @y3)
+      questioned_area =
+        triangle_area(@x1, @y1, @x2, @y2, x, y) +
+        triangle_area(@x2, @y2, @x3, @y3, x, y) +
+        triangle_area(@x3, @y3, @x1, @y1, x, y)
+
+      questioned_area <= self_area
+    end
+
     private
+
+    def triangle_area(x1, y1, x2, y2, x3, y3)
+      (x1*y2 + x2*y3 + x3*y1 - x3*y2 - x1*y3 - x2*y1).abs / 2
+    end
 
     def update_color(c)
       if c.is_a? Color::Set

--- a/test/contains.rb
+++ b/test/contains.rb
@@ -1,0 +1,32 @@
+require 'ruby2d'
+
+set title: "Ruby 2D — Contains", height: 350
+
+if RUBY_ENGINE == 'opal'
+  media = "../test/media"
+  font = "sans-serif"
+else
+  media = "media"
+  font = "#{media}/bitstream_vera/vera.ttf"
+end
+
+objects = []
+objects.push Square.new(50, 50, 100)
+objects.push Rectangle.new(200, 50, 100, 75)
+objects.push Quad.new(350, 50, 500, 75, 450, 150, 375, 125)
+objects.push Triangle.new(550, 50, 600, 125, 500, 150)
+objects.push Line.new(225, 175, 375, 225, 20)
+objects.push Image.new(50, 200, "#{media}/colors.png")
+objects.push Text.new(450, 200, "Hello", 50, font)
+
+on :key_down do |event|
+  close if event.key == 'escape'
+end
+
+update do
+  objects.each do |o|
+    o.contains?(get(:mouse_x), get(:mouse_y)) ? o.opacity = 1.0 : o.opacity = 0.5
+  end
+end
+
+show

--- a/test/image_spec.rb
+++ b/test/image_spec.rb
@@ -1,11 +1,25 @@
 require 'ruby2d'
 
 RSpec.describe Ruby2D::Image do
-
   describe '#new' do
     it "raises exception if image file doesn't exist" do
       expect { Image.new(0, 0, 'bad_image.png') }.to raise_error(Ruby2D::Error)
     end
   end
 
+  # Image has 100 width and 100 height
+  describe '#contains?' do
+    it "returns true if point is inside image" do
+      image = Image.new(0, 0, "test/media/image.bmp")
+      expect(image.contains?(50, 50)).to be true
+    end
+
+    it "returns true if point is not inside image" do
+      image = Image.new(0, 0, "test/media/image.bmp")
+      expect(image.contains?(-50, 50)).to be false
+      expect(image.contains?(50, -50)).to be false
+      expect(image.contains?(50, 150)).to be false
+      expect(image.contains?(150, 50)).to be false
+    end
+  end
 end

--- a/test/line_spec.rb
+++ b/test/line_spec.rb
@@ -1,0 +1,23 @@
+require 'ruby2d'
+
+RSpec.describe Ruby2D::Triangle do
+  describe '#contains?' do
+    it "returns true if point is inside line" do
+      line = Line.new(
+        0, 0,
+        100, 100
+      )
+      expect(line.contains?(25, 25)).to be true
+    end
+
+    it "returns true if point is inside text" do
+      line = Line.new(
+        0, 0,
+        100, 100
+      )
+
+      expect(line.contains?(0, 10)).to be false
+      expect(line.contains?(10, 0)).to be false
+    end
+  end
+end

--- a/test/quad_spec.rb
+++ b/test/quad_spec.rb
@@ -89,4 +89,30 @@ RSpec.describe Ruby2D::Quad do
       end.to raise_error("Quads require 4 colors, one for each vertex. 5 were given.")
     end
   end
+
+  describe '#contains?' do
+    it "returns true if point is inside quad" do
+      quad = Quad.new(
+        -25, 0,
+        0, -25,
+        25, 0,
+        0, 25
+      )
+      expect(quad.contains?(0, 0)).to be true
+    end
+
+    it "returns true if point is not inside quad" do
+      quad = Quad.new(
+        -25, 0,
+        0, -25,
+        25, 0,
+        0, 25
+      )
+
+      expect(quad.contains?( 20,  20)).to be false
+      expect(quad.contains?(-20,  20)).to be false
+      expect(quad.contains?( 20, -20)).to be false
+      expect(quad.contains?(-20, -20)).to be false
+    end
+  end
 end

--- a/test/rectangle_spec.rb
+++ b/test/rectangle_spec.rb
@@ -1,0 +1,18 @@
+require 'ruby2d'
+
+RSpec.describe Ruby2D::Rectangle do
+  describe '#contains?' do
+    it "returns true if point is inside rectangle" do
+      rectangle = Rectangle.new(0, 0, 50, 50)
+      expect(rectangle.contains?(25, 25)).to be true
+    end
+
+    it "returns true if point is not inside rectangle" do
+      rectangle = Rectangle.new(0, 0, 50, 50)
+      expect(rectangle.contains?(-25, 25)).to be false
+      expect(rectangle.contains?(25, -25)).to be false
+      expect(rectangle.contains?(25, 50)).to be false
+      expect(rectangle.contains?(50, 25)).to be false
+    end
+  end
+end

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -41,4 +41,19 @@ RSpec.describe Ruby2D::Text do
       expect(t.height).to eq(48)
     end
   end
+
+  describe '#contains?' do
+    it "returns true if point is inside text" do
+      text = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
+      expect(text.contains?(text.width / 2, text.height / 2)).to be true
+    end
+
+    it "returns true if point is not inside text" do
+      text = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
+      expect(text.contains?(  - text.width / 2,     text.height / 2)).to be false
+      expect(text.contains?(    text.width / 2,   - text.height / 2)).to be false
+      expect(text.contains?(3 * text.width / 2,     text.height / 2)).to be false
+      expect(text.contains?(    text.width / 2, 3 * text.height / 2)).to be false
+    end
+  end
 end

--- a/test/triangle_spec.rb
+++ b/test/triangle_spec.rb
@@ -79,4 +79,28 @@ RSpec.describe Ruby2D::Triangle do
       end.to raise_error("Triangles require 3 colors, one for each vertex. 4 were given.")
     end
   end
+
+
+  describe '#contains?' do
+    it "returns true if point is inside triangle" do
+      triangle = Triangle.new(
+        0, 0,
+        0, 100,
+        100, 0
+      )
+      expect(triangle.contains?(25, 25)).to be true
+    end
+
+    it "returns true if point is inside text" do
+      triangle = Triangle.new(
+        0, 0,
+        0, 100,
+        100, 0
+      )
+
+      expect(triangle.contains?(25, -25)).to be false
+      expect(triangle.contains?(-25, 25)).to be false
+      expect(triangle.contains?(100, 100)).to be false
+    end
+  end
 end


### PR DESCRIPTION
In this PR I added a `contains?` method for all renderable classess. For each class, this method returns true or false, based on if that point is inside the area described by that instance of that class.

For cases where the logic is nontrivial (quad, triangle, line) I added a comments describing where did the math come from. I tried to make the code rather self explanatory, so we might remove those comments if we don't want them. We might introduce private `Line#distance_to(x, y)`, and everything should be fine.

Also, I didn't add it, but maybe it would be a good idea to add a testcard-like test, with all renderable classes present, and `contains?` checked for them? For example, if object contains the point, it is red, else it is blue? This should make it visually obvious, that the code work nicely.

Other than those things, it is pretty much done.