### PR TITLE
Named arguments

### DIFF
--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -7,19 +7,24 @@ module Ruby2D
     attr_accessor :x, :y, :width, :height, :data
     attr_reader :path, :color
 
-    def initialize(x, y, path, z=0)
+    def initialize(opts = {})
+      @path = opts[:path]
 
       unless RUBY_ENGINE == 'opal'
-        unless File.exists? path
-          raise Error, "Cannot find image file `#{path}`"
+        unless File.exists? @path
+          raise Error, "Cannot find image file `#{@path}`"
         end
       end
 
+      @x = opts[:x] || 0
+      @y = opts[:y] || 0
+      @z = opts[:x] || 0
+
       @type_id = 4
-      @x, @y, @path = x, y, path
-      @z = z
-      @color = Color.new([1, 1, 1, 1])
-      ext_image_init(path)
+
+      self.color = opts[:color] || 'white'
+
+      ext_image_init(@path)
       add
     end
 

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -5,12 +5,17 @@ module Ruby2D
     include Renderable
     attr_accessor :x1, :x2, :y1, :y2, :color, :width
 
-    def initialize(x1, y1, x2, y2, width=2, c='white', z=0)
+    def initialize(opts = {})
       @type_id = 3
-      @x1, @y1, @x2, @y2 = x1, y1, x2, y2
-      @width = width
-      @z = z
-      self.color = c
+
+      @x1 = opts[:x1] || 0
+      @y1 = opts[:y1] || 0
+      @x2 = opts[:x2] || 100
+      @y2 = opts[:y2] || 100
+      @width = opts[:width] || 2
+      @z = opts[:z] || 0
+      self.color = opts[:color] || 'white'
+
       add
     end
 

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -15,12 +15,21 @@ module Ruby2D
 
     attr_reader :color
 
-    def initialize(x1=0, y1=0, x2=100, y2=0, x3=100, y3=100, x4=100, y4=100, c='white', z=0)
+    def initialize(opts = {})
       @type_id = 2
-      @x1, @y1, @x2, @y2, @x3, @y3, @x4, @y4 = x1, y1, x2, y2, x3, y3, x4, y4
-      @z = z
 
-      self.color = c
+      @x1 = opts[:x1] || 0
+      @y1 = opts[:y1] || 0
+      @x2 = opts[:x2] || 100
+      @y2 = opts[:y2] || 0
+      @x3 = opts[:x3] || 100
+      @y3 = opts[:y3] || 100
+      @x4 = opts[:x4] || 0
+      @y4 = opts[:y4] || 100
+
+      @z = opts[:z] || 0
+
+      self.color = opts[:color] || 'white'
       add
     end
 

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -5,13 +5,18 @@ module Ruby2D
 
     attr_reader :x, :y, :width, :height
 
-    def initialize(x=0, y=0, w=200, h=100, c='white', z=0)
+    def initialize(opts = {})
       @type_id = 2
-      @x, @y, @width, @height = x, y, w, h
-      @z = z
-      update_coords(x, y, w, h)
 
-      self.color = c
+      @x      = opts[:x]      || 0
+      @y      = opts[:y]      || 0
+      @z      = opts[:z]      || 0
+      @width  = opts[:width]  || 200
+      @height = opts[:height] || 100
+
+      update_coords(@x, @y, @width, @height)
+
+      self.color = opts[:color] || 'white'
       add
     end
 

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -5,14 +5,17 @@ module Ruby2D
 
     attr_reader :size
 
-    def initialize(x=0, y=0, s=100, c='white', z=0)
+    def initialize(opts = {})
       @type_id = 2
-      @x, @y = x, y
-      @width = @height = @size = s
-      @z = z
-      update_coords(x, y, s, s)
+      @x = opts[:x] || 0
+      @y = opts[:y] || 0
+      @z = opts[:z] || 0
+      @width = @height = @size = opts[:size] || 100
 
-      self.color = c
+      self.color = opts[:color] || 'white'
+
+      update_coords(@x, @y, @size, @size)
+
       add
     end
 

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -7,19 +7,18 @@ module Ruby2D
     attr_accessor :x, :y, :data
     attr_reader :text, :size, :width, :height, :font, :color
 
-    def initialize(x=0, y=0, text="Hello World!", size=20, font=nil, c='white', z=0)
-
-      # if File.exists? font
-        @font = font
-      # else
-      #   @font = resolve_path(font)
-      # end
-
+    def initialize(opts = {})
       @type_id = 6
-      @x, @y, @size = x, y, size
-      @z = z
-      @text = text.to_s
-      self.color = c
+
+      @x = opts[:x] || 0
+      @y = opts[:y] || 0
+      @z = opts[:z] || 0
+      @text = (opts[:text] || "Hello World!").to_s
+      @size = opts[:size] || 20
+
+      @font = opts[:font]
+
+      self.color = opts[:color] || 'white'
       ext_text_init
       add
     end

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -9,14 +9,18 @@ module Ruby2D
                   :x3, :y3, :c3
     attr_reader :color, :type_id
 
-    def initialize(x1=50, y1=0, x2=100, y2=100, x3=0, y3=100, c='white', z=0)
+    def initialize(opts= {})
       @type_id = 1
-      @x1, @y1 = x1, y1
-      @x2, @y2 = x2, y2
-      @x3, @y3 = x3, y3
-      @z = z
 
-      self.color = c
+      @x1 = opts[:x1] || 50
+      @y1 = opts[:y1] || 0
+      @x2 = opts[:x2] || 100
+      @y2 = opts[:y2] || 100
+      @x3 = opts[:x3] || 0
+      @y3 = opts[:y3] || 100
+      @z = opts[:z] || 0
+
+      self.color = opts[:color] || 'white'
       add
     end
 

--- a/test/color_spec.rb
+++ b/test/color_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Ruby2D::Color do
     it 'sets and returns the opacity' do
       s1 = Square.new
       s1.opacity = 0.5
-      s2 = Square.new(0, 0, 0, ['red', 'green', 'blue', 'yellow'])
+      s2 = Square.new(color: ['red', 'green', 'blue', 'yellow'])
       s2.opacity = 0.7
       expect(s1.opacity).to eq 0.5
       expect(s2.opacity).to eq 0.7

--- a/test/contains.rb
+++ b/test/contains.rb
@@ -11,13 +11,13 @@ else
 end
 
 objects = []
-objects.push Square.new(50, 50, 100)
-objects.push Rectangle.new(200, 50, 100, 75)
-objects.push Quad.new(350, 50, 500, 75, 450, 150, 375, 125)
-objects.push Triangle.new(550, 50, 600, 125, 500, 150)
-objects.push Line.new(225, 175, 375, 225, 20)
-objects.push Image.new(50, 200, "#{media}/colors.png")
-objects.push Text.new(450, 200, "Hello", 50, font)
+objects.push Square.new(x: 50, y: 50, size: 100)
+objects.push Rectangle.new(x: 200, y: 50, width: 100, height: 75)
+objects.push Quad.new(x1: 350, y1: 50, x2: 500, y2: 75, x3: 450, y3: 150, x4: 375, y4: 125)
+objects.push Triangle.new(x1: 550, y1: 50, x2: 600, y2: 125, x3: 500, y3: 150)
+objects.push Line.new(x1: 225, y1: 175, x2: 375, y2: 225, width: 20)
+objects.push Image.new(x: 50, y: 200, path: "#{media}/colors.png")
+objects.push Text.new(x: 450, y: 200, text: "Hello", size: 50, font: font)
 
 on :key_down do |event|
   close if event.key == 'escape'

--- a/test/image_spec.rb
+++ b/test/image_spec.rb
@@ -3,19 +3,19 @@ require 'ruby2d'
 RSpec.describe Ruby2D::Image do
   describe '#new' do
     it "raises exception if image file doesn't exist" do
-      expect { Image.new(0, 0, 'bad_image.png') }.to raise_error(Ruby2D::Error)
+      expect { Image.new(path: 'bad_image.png') }.to raise_error(Ruby2D::Error)
     end
   end
 
   # Image has 100 width and 100 height
   describe '#contains?' do
     it "returns true if point is inside image" do
-      image = Image.new(0, 0, "test/media/image.bmp")
+      image = Image.new(path: "test/media/image.bmp")
       expect(image.contains?(50, 50)).to be true
     end
 
     it "returns true if point is not inside image" do
-      image = Image.new(0, 0, "test/media/image.bmp")
+      image = Image.new(path: "test/media/image.bmp")
       expect(image.contains?(-50, 50)).to be false
       expect(image.contains?(50, -50)).to be false
       expect(image.contains?(50, 150)).to be false

--- a/test/key.rb
+++ b/test/key.rb
@@ -2,8 +2,17 @@ require 'ruby2d'
 
 set title: "Ruby 2D — Key", width: 300, height: 200
 
-s1 = Square.new(5, 5, 50, [1, 1, 1, 1])
-s2 = Square.new(60, 5, 50, [1, 1, 1, 1])
+s1 = Square.new(
+  x: 5,
+  y: 5,
+  size: 50
+)
+
+s2 = Square.new(
+  x: 60,
+  y: 5,
+  size: 50
+)
 
 on :key do |event|
   puts event

--- a/test/line_spec.rb
+++ b/test/line_spec.rb
@@ -3,19 +3,11 @@ require 'ruby2d'
 RSpec.describe Ruby2D::Triangle do
   describe '#contains?' do
     it "returns true if point is inside line" do
-      line = Line.new(
-        0, 0,
-        100, 100
-      )
+      line = Line.new(x1: 0, y1: 0, x2: 100, y2: 100)
       expect(line.contains?(25, 25)).to be true
     end
-
     it "returns true if point is inside text" do
-      line = Line.new(
-        0, 0,
-        100, 100
-      )
-
+      line = Line.new(x1: 0, y1: 0, x2: 100, y2: 100)
       expect(line.contains?(0, 10)).to be false
       expect(line.contains?(10, 0)).to be false
     end

--- a/test/mouse.rb
+++ b/test/mouse.rb
@@ -6,10 +6,10 @@ on :mouse do |event|
   puts event
 end
 
-s1 = Square.new(5, 5, 25, [1, 1, 0, 1])      # mouse down square
-s2 = Square.new(188, 10, 25)                 # mouse scroll square
-s3 = Square.new(188, 137, 25, [1, 1, 1, 1])  # mouse move delta square
-s4 = Square.new(35, 5, 10)                   # mouse move position square
+s1 = Square.new(x: 5,   y: 5,   size: 25, color: [1, 1, 0, 1]) # mouse down square
+s2 = Square.new(x: 188, y: 10,  size: 25)                      # mouse scroll square
+s3 = Square.new(x: 188, y: 137, size: 25)                      # mouse move delta square
+s4 = Square.new(x: 35,  y: 5,   size: 10)                      # mouse move position square
 
 on :mouse_down do |event|
   case event.button
@@ -43,8 +43,8 @@ on :mouse_move do |event|
 end
 
 # Crosshairs
-Rectangle.new(199, 0, 2, 300, [1, 0, 0, 1])
-Rectangle.new(0, 149, 400, 2, [1, 0, 0, 1])
+Rectangle.new(x: 199, y: 0,   width: 2,   height: 300, color: [1, 0, 0, 1])
+Rectangle.new(x: 0,   y: 149, width: 400, height: 2,   color: [1, 0, 0, 1])
 
 on :key_down do |event|
   close if event.key == 'escape'

--- a/test/quad_spec.rb
+++ b/test/quad_spec.rb
@@ -3,13 +3,7 @@ require 'ruby2d'
 RSpec.describe Ruby2D::Quad do
   describe '#new' do
     it "creates a quad with white color by default" do
-      quad = Quad.new(
-        300, 200,
-        350, 200,
-        300, 250,
-        250, 250
-      )
-
+      quad = Quad.new
       expect(quad.color).to   be_a(Ruby2D::Color)
       expect(quad.color.r).to eq(1)
       expect(quad.color.g).to eq(1)
@@ -18,48 +12,28 @@ RSpec.describe Ruby2D::Quad do
     end
 
     it 'creates a new quad with one color via string' do
-      quad = Quad.new(
-        300, 200,
-        350, 200,
-        300, 250,
-        250, 250,
-        "red"
-      )
-
+      quad = Quad.new(color: "red")
       expect(quad.color).to be_a(Ruby2D::Color)
     end
 
     it "creates a new triangle with one color via array of numbers" do
-      quad = Quad.new(
-        300, 200,
-        350, 200,
-        300, 250,
-        250, 250,
-        [0.1, 0.3, 0.5, 0.7]
-      )
-
+      quad = Quad.new(color: [0.1, 0.3, 0.5, 0.7])
       expect(quad.color).to be_a(Ruby2D::Color)
     end
 
     it "creates a new quad with 4 colors via array of 4 strings" do
-      quad = Quad.new(
-        300, 200,
-        350, 200,
-        300, 250,
-        250, 250,
-        ["red", "green", "blue", "black"]
-      )
-
+      quad = Quad.new(color: ["red", "green", "blue", "black"])
       expect(quad.color).to be_a(Ruby2D::Color::Set)
     end
 
     it "creates a new quad with 4 colors via array of 4 arrays of arrays of numbers" do
       quad = Quad.new(
-        300, 200,
-        350, 200,
-        300, 250,
-        250, 250,
-        [[0.1, 0.3, 0.5, 0.7], [0.2, 0.4, 0.6, 0.8], [0.3, 0.5, 0.7, 0.9], [0.4, 0.6, 0.8, 1.0]]
+        color: [
+          [0.1, 0.3, 0.5, 0.7],
+          [0.2, 0.4, 0.6, 0.8],
+          [0.3, 0.5, 0.7, 0.9],
+          [0.4, 0.6, 0.8, 1.0]
+        ]
       )
 
       expect(quad.color).to be_a(Ruby2D::Color::Set)
@@ -67,25 +41,13 @@ RSpec.describe Ruby2D::Quad do
 
     it "throws an error when array of 3 strings is passed" do
       expect do
-        Quad.new(
-          300, 200,
-          350, 200,
-          300, 250,
-          250, 250,
-          ["red", "green", "blue"]
-        )
+        Quad.new(color: ["red", "green", "blue"])
       end.to raise_error("Quads require 4 colors, one for each vertex. 3 were given.")
     end
 
     it "throws an error when array of 5 strings is passed" do
       expect do
-        Quad.new(
-          300, 200,
-          350, 200,
-          300, 250,
-          250, 250,
-          ["red", "green", "blue", "black", "fuchsia"]
-        )
+        Quad.new(color: ["red", "green", "blue", "black", "fuchsia"])
       end.to raise_error("Quads require 4 colors, one for each vertex. 5 were given.")
     end
   end
@@ -93,22 +55,21 @@ RSpec.describe Ruby2D::Quad do
   describe '#contains?' do
     it "returns true if point is inside quad" do
       quad = Quad.new(
-        -25, 0,
-        0, -25,
-        25, 0,
-        0, 25
+        x1: -25, y1:   0,
+        x2:   0, y2: -25,
+        x3:  25, y3:   0,
+        x4:   0, y4:  25
       )
       expect(quad.contains?(0, 0)).to be true
     end
 
     it "returns true if point is not inside quad" do
       quad = Quad.new(
-        -25, 0,
-        0, -25,
-        25, 0,
-        0, 25
+        x1: -25, y1:   0,
+        x2:   0, y2: -25,
+        x3:  25, y3:   0,
+        x4:   0, y4:  25
       )
-
       expect(quad.contains?( 20,  20)).to be false
       expect(quad.contains?(-20,  20)).to be false
       expect(quad.contains?( 20, -20)).to be false

--- a/test/rectangle_spec.rb
+++ b/test/rectangle_spec.rb
@@ -3,16 +3,16 @@ require 'ruby2d'
 RSpec.describe Ruby2D::Rectangle do
   describe '#contains?' do
     it "returns true if point is inside rectangle" do
-      rectangle = Rectangle.new(0, 0, 50, 50)
+      rectangle = Rectangle.new(x: 0, y: 0, width: 50, height: 50)
       expect(rectangle.contains?(25, 25)).to be true
     end
 
     it "returns true if point is not inside rectangle" do
-      rectangle = Rectangle.new(0, 0, 50, 50)
-      expect(rectangle.contains?(-25, 25)).to be false
-      expect(rectangle.contains?(25, -25)).to be false
-      expect(rectangle.contains?(25, 50)).to be false
-      expect(rectangle.contains?(50, 25)).to be false
+      rectangle = Rectangle.new(x: 0, y: 0, width: 50, height: 50)
+      expect(rectangle.contains?(-25,  25)).to be false
+      expect(rectangle.contains?( 25, -25)).to be false
+      expect(rectangle.contains?( 25,  50)).to be false
+      expect(rectangle.contains?( 50,  25)).to be false
     end
   end
 end

--- a/test/testcard.rb
+++ b/test/testcard.rb
@@ -21,101 +21,139 @@ Height: #{get :height}
 Window: #{get :window}\n\n"
 
 # Primary colors
-Rectangle.new(0, 0, 50, 100,   [1, 0, 0, 1])
-Rectangle.new(50, 0, 50, 100,  [0, 1, 0, 1])
-Rectangle.new(100, 0, 50, 100, [0, 0, 1, 1])
+Rectangle.new(x: 0,   width: 50, color: [1, 0, 0, 1])
+Rectangle.new(x: 50,  width: 50, color: [0, 1, 0, 1])
+Rectangle.new(x: 100, width: 50, color: [0, 0, 1, 1])
 
 # Color strings
-Square.new(   150, 0, 50,      'teal')
-Square.new(   200, 0, 50,      'gray')
-Square.new(   250, 0, 50,      'silver')
-Square.new(   300, 0, 50,      'white')
-Rectangle.new(350, 0, 50, 50,  'navy')
-Rectangle.new(400, 0, 50, 50,  'blue')
-Rectangle.new(450, 0, 50, 50,  'aqua')
-Rectangle.new(500, 0, 50, 50,  'teal')
-Rectangle.new(550, 0, 50, 50,  'olive')
+Square.new(x: 150, size: 50, color: 'teal')
+Square.new(x: 200, size: 50, color: 'gray')
+Square.new(x: 250, size: 50, color: 'silver')
+Square.new(x: 300, size: 50, color: 'white')
+Rectangle.new(x: 350, width: 50, height: 50, color: 'navy')
+Rectangle.new(x: 400, width: 50, height: 50, color: 'blue')
+Rectangle.new(x: 450, width: 50, height: 50, color: 'aqua')
+Rectangle.new(x: 500, width: 50, height: 50, color: 'teal')
+Rectangle.new(x: 550, width: 50, height: 50, color: 'olive')
 
-Rectangle.new(150, 50, 50, 50, 'green')
-Rectangle.new(200, 50, 50, 50, 'lime')
-Rectangle.new(250, 50, 50, 50, 'yellow')
-Rectangle.new(300, 50, 50, 50, 'orange')
-Rectangle.new(350, 50, 50, 50, 'red')
-Rectangle.new(400, 50, 50, 50, 'maroon')
-Rectangle.new(450, 50, 50, 50, 'fuchsia')
-Rectangle.new(500, 50, 50, 50, 'purple')
-Rectangle.new(550, 50, 50, 50, 'brown')
+Rectangle.new(x: 150, y: 50, width: 50, height: 50, color: 'green')
+Rectangle.new(x: 200, y: 50, width: 50, height: 50, color: 'lime')
+Rectangle.new(x: 250, y: 50, width: 50, height: 50, color: 'yellow')
+Rectangle.new(x: 300, y: 50, width: 50, height: 50, color: 'orange')
+Rectangle.new(x: 350, y: 50, width: 50, height: 50, color: 'red')
+Rectangle.new(x: 400, y: 50, width: 50, height: 50, color: 'maroon')
+Rectangle.new(x: 450, y: 50, width: 50, height: 50, color: 'fuchsia')
+Rectangle.new(x: 500, y: 50, width: 50, height: 50, color: 'purple')
+Rectangle.new(x: 550, y: 50, width: 50, height: 50, color: 'brown')
 
 # Mix of named colors and numbers
-Rectangle.new(600, 0, 50, 50,
-[
-  'red',
-  'green',
-  'blue',
-  'yellow'
-])
-Rectangle.new(650, 0, 50, 50,
-[
-  [1.0, 0, 0, 1],
-  'green',
-  [0.0, 0, 1, 1.0],
-  'yellow'
-])
-Rectangle.new(600, 50, 50, 50, 'random')
-Rectangle.new(650, 50, 50, 50, 'random')
+Rectangle.new(
+  x: 600,
+  width: 50,
+  height: 50,
+  color: [
+    'red',
+    'green',
+    'blue',
+    'yellow'
+  ]
+)
+Rectangle.new(
+  x: 650,
+  y: 0,
+  width: 50,
+  height: 50,
+  color: [
+    [1.0, 0, 0, 1],
+    'green',
+    [0.0, 0, 1, 1.0],
+    'yellow'
+  ]
+)
+Rectangle.new(x: 600, y: 50, width: 50, height: 50, color: 'random')
+Rectangle.new(x: 650, y: 50, width: 50, height: 50, color: 'random')
 
 # White to black gradient
-Rectangle.new(0, 100, 700, 25,
-[
-  [1.0, 1.0, 1.0, 1.0],
-  [0.0, 0.0, 0.0, 0.0],
-  [0.0, 0.0, 0.0, 0.0],
-  [1.0, 1.0, 1.0, 1.0]
-])
+Rectangle.new(
+  x: 0,
+  y: 100,
+  width: 700,
+  height: 25,
+  color: [
+    [1.0, 1.0, 1.0, 1.0],
+    [0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0],
+    [1.0, 1.0, 1.0, 1.0]
+  ]
+)
 
 # Color gradient
-Rectangle.new(0, 125, 700, 50,
-[
-  [1.0, 0.0, 0.0, 1.0],
-  [0.0, 1.0, 0.0, 1.0],
-  [0.0, 0.0, 1.0, 1.0],
-  [1.0, 1.0, 0.0, 1.0]
-])
+Rectangle.new(
+  x: 0,
+  y: 125,
+  width: 700,
+  height: 50,
+  color: [
+    [1.0, 0.0, 0.0, 1.0],
+    [0.0, 1.0, 0.0, 1.0],
+    [0.0, 0.0, 1.0, 1.0],
+    [1.0, 1.0, 0.0, 1.0]
+  ]
+)
 
 # Transparancy
-Rectangle.new(0, 165, 700, 35,
-[
-  [1.0, 1.0, 1.0, 0.0],
-  [1.0, 1.0, 1.0, 1.0],
-  [1.0, 1.0, 1.0, 1.0],
-  [1.0, 1.0, 1.0, 0.0]
-])
+Rectangle.new(
+  x: 0,
+  y: 165,
+  width: 700,
+  height: 35,
+  color: [
+    [1.0, 1.0, 1.0, 0.0],
+    [1.0, 1.0, 1.0, 1.0],
+    [1.0, 1.0, 1.0, 1.0],
+    [1.0, 1.0, 1.0, 0.0]
+  ]
+)
 
 # Triangles
-Triangle.new(25, 200, 50, 250, 0, 250,     [1.0,   0,   0, 1.0])
-Triangle.new(75, 200, 100, 250, 50, 250,   [  0, 1.0,   0, 1.0])
-Triangle.new(125, 200, 150, 250, 100, 250, [  0,   0, 1.0, 1.0])
-Triangle.new(175, 200, 200, 250, 150, 250,
-[
-  [1.0, 0, 0, 1.0],
-  [0, 1.0, 0, 1.0],
-  [0, 0, 1.0, 1.0]
-])
-Rectangle.new(200, 200, 50, 50, [0.5, 0.5, 0.5, 1.0])  # add background for transparancy
-Triangle.new(225, 200, 250, 250, 200, 250,
-[
-  [1.0, 1.0, 1.0, 1.0],
-  [0.0, 0.0, 0.0, 1.0],
-  [1.0, 1.0, 1.0, 0.0]
-])
+Triangle.new(x1: 25,  y1: 200, x2: 50,  y2: 250, x3: 0,   y3: 250, color: [1.0,   0,   0, 1.0])
+Triangle.new(x1: 75,  y1: 200, x2: 100, y2: 250, x3: 50,  y3: 250, color: [  0, 1.0,   0, 1.0])
+Triangle.new(x1: 125, y1: 200, x2: 150, y2: 250, x3: 100, y3: 250, color: [  0,   0, 1.0, 1.0])
+Triangle.new(x1: 175, y1: 200, x2: 200, y2: 250, x3: 150, y3: 250,
+  color: [
+    [1.0, 0, 0, 1.0],
+    [0, 1.0, 0, 1.0],
+    [0, 0, 1.0, 1.0]
+  ]
+)
+Rectangle.new(
+  x: 200,
+  y: 200,
+  width: 50,
+  height: 50,
+  color: [0.5, 0.5, 0.5, 1.0]
+)  # add background for transparancy
+Triangle.new(
+  x1: 225,
+  y1: 200,
+  x2: 250,
+  y2: 250,
+  x3: 200,
+  y3: 250,
+  color: [
+    [1.0, 1.0, 1.0, 1.0],
+    [0.0, 0.0, 0.0, 1.0],
+    [1.0, 1.0, 1.0, 0.0]
+  ]
+)
 
 # Quadrilaterals
 Quad.new(
-  300, 200,
-  350, 200,
-  300, 250,
-  250, 250,
-  [
+  x1: 300, y1: 200,
+  x2: 350, y2: 200,
+  x3: 300, y3: 250,
+  x4: 250, y4: 250,
+  color: [
     [1.0, 0.0, 0.0, 1.0],
     [0.0, 1.0, 0.0, 1.0],
     [0.0, 0.0, 1.0, 1.0],
@@ -124,11 +162,11 @@ Quad.new(
 )
 
 Quad.new(
-  250, 200,
-  300, 200,
-  350, 250,
-  300, 250,
-  [
+  x1: 250, y1: 200,
+  x2: 300, y2: 200,
+  x3: 350, y3: 250,
+  x4: 300, y4: 250,
+  color: [
     [1.0, 1.0, 1.0, 0.0],
     [1.0, 1.0, 1.0, 0.0],
     [1.0, 1.0, 1.0, 1.0],
@@ -138,9 +176,10 @@ Quad.new(
 
 # Lines
 Line.new(
-  354, 204, 397, 247,
-  11,
-  [
+  x1: 354, y1: 204,
+  x2: 397, y2: 247,
+  width: 11,
+  color: [
     [1, 1, 1, 1],
     [1, 1, 1, 1],
     [1, 1, 1, 1],
@@ -149,9 +188,10 @@ Line.new(
 );
 
 Line.new(
-  395, 205, 355, 245,
-  15,
-  [
+  x1: 395, y1: 205,
+  x2: 355, y2: 245,
+  width: 15,
+  color: [
     [1, 0, 0, 0.5],
     [0, 1, 0, 0.5],
     [0, 0, 1, 0.5],
@@ -160,29 +200,26 @@ Line.new(
 );
 
 # Images
-Image.new(590, 180, "#{media}/image.png")
-Image.new(590, 290, "#{media}/image.jpg")
-Image.new(590, 400, "#{media}/image.bmp")
-img_r = Image.new(400, 200, "#{media}/colors.png")
+Image.new(x: 590, y: 180, path: "#{media}/image.png")
+Image.new(x: 590, y: 290, path: "#{media}/image.jpg")
+Image.new(x: 590, y: 400, path: "#{media}/image.bmp")
+img_r = Image.new(x: 400, y: 200, path: "#{media}/colors.png")
 img_r.width, img_r.height = 50, 25
 img_r.color = [1.0, 0.3, 0.3, 1.0]
-img_g = Image.new(400, 225, "#{media}/colors.png")
+img_g = Image.new(x: 400, y: 225, path: "#{media}/colors.png")
 img_g.width, img_g.height = 25, 25
 img_g.color = [0.3, 1.0, 0.3, 1.0]
-img_b = Image.new(425, 225, "#{media}/colors.png")
+img_b = Image.new(x: 425, y: 225, path: "#{media}/colors.png")
 img_b.width, img_b.height = 25, 25
 img_b.color = [0.3, 0.3, 1.0, 1.0]
 
 # Text
-txt_r = Text.new( 44, 202, "R", 20, font)
-txt_r.color = [1.0, 0.0, 0.0, 1.0]
-txt_g = Text.new( 92, 202, "G", 20, font)
-txt_g.color = [0.0, 1.0, 0.0, 1.0]
-txt_b = Text.new(144, 202, "B", 20, font)
-txt_b.color = [0.0, 0.0, 1.0, 1.0]
+Text.new(x: 44,  y: 202, text: "R", font: font, color: [1.0, 0.0, 0.0, 1.0])
+Text.new(x: 92,  y: 202, text: "G", font: font, color: [0.0, 1.0, 0.0, 1.0])
+Text.new(x: 144, y: 202, text: "B", font: font, color: [0.0, 0.0, 1.0, 1.0])
 
 # Frames per second
-fps = Text.new(10, 470, "", 20, font)
+fps = Text.new(x: 10, y: 470, text: "", font: font)
 
 # Sprites
 s1 = Sprite.new(450, 200, "#{media}/sprite_sheet.png")
@@ -194,33 +231,43 @@ s1.add(forwards: [
 ])
 
 # Pointer for mouse
-pointer = Square.new(0, 0, 10, [1, 1, 1, 1])
-pointer_outline = Square.new(0, 0, 18, [0, 1, 0, 0])
+pointer = Square.new(size: 10)
+pointer_outline = Square.new(size: 18, color: [0, 1, 0, 0])
 flash = 0
 
 # Updating opacity
-opacity_square = Square.new(500, 200, 50, ["red", "green", "blue", "yellow"])
-time_start     = Time.now
+opacity_square = Square.new(
+  x: 500,
+  y: 200,
+  size: 50,
+  color: ["red", "green", "blue", "yellow"]
+)
+time_start = Time.now
 
 # Text size
-created_text = Text.new(10, 270, "Created text", 20, font)
+created_text = Text.new(x: 10, y: 270, text: "Created text", font: font)
 created_text_background = Rectangle.new(
-  created_text.x - 10,
-  created_text.y - 10,
-  created_text.width + 20,
-  created_text.height + 20,
-  "red"
+  x: created_text.x - 10,
+  y: created_text.y - 10,
+  width: created_text.width + 20,
+  height: created_text.height + 20,
+  color: "red"
 )
 created_text.remove
 created_text.add
 
-updated_text = Text.new(20 + created_text_background.x2, 270, "Updated text", 20, font)
+updated_text = Text.new(
+  x: 20 + created_text_background.x2,
+  y: 270,
+  text: "Updated text",
+  font: font
+)
 updated_text_background = Rectangle.new(
-  updated_text.x - 10,
-  updated_text.y - 10,
-  updated_text.width + 20,
-  updated_text.height + 20,
-  "blue"
+  x: updated_text.x - 10,
+  y: updated_text.y - 10,
+  width: updated_text.width + 20,
+  height: updated_text.height + 20,
+  color: "blue"
 )
 updated_text.remove
 updated_text.add

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Ruby2D::Text do
 
   describe '#text=' do
     it 'maps Time to string' do
-      t = Text.new(0, 0, Time.now, 40, "test/media/bitstream_vera/vera.ttf")
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
       t.text = Time.new(1, 1, 1, 1, 1, 1, 1)
       expect(t.text).to eq "0001-01-01 01:01:01 +0000"
     end
 
     it 'maps Number to string' do
-      t = Text.new(0, 0, 0, 40, "test/media/bitstream_vera/vera.ttf")
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
       t.text = 0
       expect(t.text).to eq "0"
     end
@@ -18,42 +18,44 @@ RSpec.describe Ruby2D::Text do
 
   describe "#width" do
     it "is known after creation" do
-      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
-      expect(t.width).to eq(239)
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      expect(t.width).to eq(123)
     end
 
     it "is known after updating" do
-      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
-      t.text = "Hello world!"
-      expect(t.width).to eq(239)
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      t.text = "Hello!"
+      expect(t.width).to eq(59)
     end
   end
 
   describe "#height" do
     it "is known after creation" do
-      t = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
-      expect(t.height).to eq(48)
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      expect(t.height).to eq(24)
     end
 
     it "is known after updating" do
-      t = Text.new(0, 0, "Good morning world!", 40, "test/media/bitstream_vera/vera.ttf")
-      t.text = "Hello world!"
-      expect(t.height).to eq(48)
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      t.text = "Good morning world!"
+      expect(t.height).to eq(24)
     end
   end
 
   describe '#contains?' do
     it "returns true if point is inside text" do
-      text = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
-      expect(text.contains?(text.width / 2, text.height / 2)).to be true
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      t.text = "Hello world!"
+      expect(t.contains?(t.width / 2, t.height / 2)).to be true
     end
 
     it "returns true if point is not inside text" do
-      text = Text.new(0, 0, "Hello world!", 40, "test/media/bitstream_vera/vera.ttf")
-      expect(text.contains?(  - text.width / 2,     text.height / 2)).to be false
-      expect(text.contains?(    text.width / 2,   - text.height / 2)).to be false
-      expect(text.contains?(3 * text.width / 2,     text.height / 2)).to be false
-      expect(text.contains?(    text.width / 2, 3 * text.height / 2)).to be false
+      t = Text.new(font: "test/media/bitstream_vera/vera.ttf")
+      t.text = "Hello world!"
+      expect(t.contains?(  - t.width / 2,     t.height / 2)).to be false
+      expect(t.contains?(    t.width / 2,   - t.height / 2)).to be false
+      expect(t.contains?(3 * t.width / 2,     t.height / 2)).to be false
+      expect(t.contains?(    t.width / 2, 3 * t.height / 2)).to be false
     end
   end
 end

--- a/test/triangle.rb
+++ b/test/triangle.rb
@@ -3,10 +3,10 @@ require 'ruby2d'
 set title: "Hello Triangle"
 
 Triangle.new(
-  320,  50,
-  540, 430,
-  100, 430,
-  ['red', 'green', 'blue']
+  x1: 320, y1:  50,
+  x2: 540, y2: 430,
+  x3: 100, y3: 430,
+  color: ['red', 'green', 'blue']
 )
 
 show

--- a/test/triangle_spec.rb
+++ b/test/triangle_spec.rb
@@ -3,11 +3,7 @@ require 'ruby2d'
 RSpec.describe Ruby2D::Triangle do
   describe '#new' do
     it "creates a triangle with white color by default" do
-      triangle = Triangle.new(
-        320,  50,
-        540, 430,
-        100, 430
-      )
+      triangle = Triangle.new
       expect(triangle.color).to   be_a(Ruby2D::Color)
       expect(triangle.color.r).to eq(1)
       expect(triangle.color.g).to eq(1)
@@ -16,66 +12,40 @@ RSpec.describe Ruby2D::Triangle do
     end
 
     it 'creates a new triangle with one color via string' do
-      triangle = Triangle.new(
-        320,  50,
-        540, 430,
-        100, 430,
-        "black"
-      )
-
+      triangle = Triangle.new(color: "black")
       expect(triangle.color).to be_a(Ruby2D::Color)
     end
 
     it "creates a new triangle with one color via array of numbers" do
-      triangle = Triangle.new(
-        320,  50,
-        540, 430,
-        100, 430,
-        [0.1, 0.3, 0.5, 0.7]
-      )
-
+      triangle = Triangle.new(color: [0.1, 0.3, 0.5, 0.7])
       expect(triangle.color).to be_a(Ruby2D::Color)
     end
 
     it "creates a new triangle with 3 colors via array of 3 strings" do
-      triangle = Triangle.new(
-        320,  50,
-        540, 430,
-        100, 430,
-        ["red", "green", "blue"]
-      )
+      triangle = Triangle.new(color: ["red", "green", "blue"])
       expect(triangle.color).to be_a(Ruby2D::Color::Set)
     end
 
     it "creates a new triangle with 3 colors via array of 3 arrays of arrays of numbers" do
       triangle = Triangle.new(
-        320,  50,
-        540, 430,
-        100, 430,
-        [[0.1, 0.3, 0.5, 0.7], [0.2, 0.4, 0.6, 0.8], [0.3, 0.5, 0.7, 0.9]]
+        color: [
+          [0.1, 0.3, 0.5, 0.7],
+          [0.2, 0.4, 0.6, 0.8],
+          [0.3, 0.5, 0.7, 0.9]
+        ]
       )
       expect(triangle.color).to be_a(Ruby2D::Color::Set)
     end
 
     it "throws an error when array of 2 strings is passed" do
       expect do
-        Triangle.new(
-          320,  50,
-          540, 430,
-          100, 430,
-          ["red", "green"]
-        )
+        Triangle.new(color: ["red", "green"])
       end.to raise_error("Triangles require 3 colors, one for each vertex. 2 were given.")
     end
 
     it "throws an error when array of 4 strings is passed" do
       expect do
-        Triangle.new(
-          320,  50,
-          540, 430,
-          100, 430,
-          ["red", "green", "blue", "fuchsia"]
-        )
+        Triangle.new(color: ["red", "green", "blue", "fuchsia"])
       end.to raise_error("Triangles require 3 colors, one for each vertex. 4 were given.")
     end
   end
@@ -84,22 +54,21 @@ RSpec.describe Ruby2D::Triangle do
   describe '#contains?' do
     it "returns true if point is inside triangle" do
       triangle = Triangle.new(
-        0, 0,
-        0, 100,
-        100, 0
+        x1:   0, y1:   0,
+        x2:   0, y2: 100,
+        x3: 100, y3:   0
       )
       expect(triangle.contains?(25, 25)).to be true
     end
 
     it "returns true if point is inside text" do
       triangle = Triangle.new(
-        0, 0,
-        0, 100,
-        100, 0
+        x1:   0, y1:   0,
+        x2:   0, y2: 100,
+        x3: 100, y3:   0
       )
-
-      expect(triangle.contains?(25, -25)).to be false
-      expect(triangle.contains?(-25, 25)).to be false
+      expect(triangle.contains?( 25, -25)).to be false
+      expect(triangle.contains?(-25,  25)).to be false
       expect(triangle.contains?(100, 100)).to be false
     end
   end

--- a/test/z_index.rb
+++ b/test/z_index.rb
@@ -23,8 +23,20 @@ class Ruby2D::Square
 end
 
 objects = []
-objects << Square.new(50, 50, 200, "red",   @z_index_generator.get)
-objects << Square.new(100, 50, 200, "blue", @z_index_generator.get)
+objects << Square.new(
+  x: 50,
+  y: 50,
+  size: 200,
+  color: "red",
+  z: @z_index_generator.get
+)
+objects << Square.new(
+  x: 100,
+  y: 50,
+  size: 200,
+  color: "blue",
+  z: @z_index_generator.get
+)
 
 on :mouse_down do |event|
   x = event.x
@@ -39,7 +51,13 @@ on :mouse_down do |event|
     first_object.z = @z_index_generator.get if first_object
   when :right
     # Add new square with z-index of zero, with the middle at mouse position
-    objects << Square.new(x - 100, y - 100, 200, "random", -objects.count)
+    objects << Square.new(
+      x: x - 100,
+      y: y - 100,
+      size: 200,
+      color: "random",
+      z: -objects.count
+    )
   end
 end
 


### PR DESCRIPTION
This pull request updates all renderable classess to use named arguments. It does not update `Sprite` class, I'm not sure if it is actually ready to be used. If need be, I will update it too.

In the spirit of this change, I also made sure that all classess are initialized properly without any arguments (except Text, which has to have default font PR merged for this).

Also in spirit of this change, I removed attributes in constructor wherever they matched the default and it made things more clear. It is very nicely visible in tests for Quad and Triangle, where I was able to remove all position attributes, since only color was tested.

I noticed that default attributes for Quad were actually drawing a triangle instead of a quad, and I fixed that as well.