### PR TITLE
dispatch rendering to rendered classess

### DIFF
--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -4,19 +4,10 @@
 $R2D_WINDOW = nil
 
 # Simple 2D window
-`var win;`
+`
+var win;
 
-
-`// ruby2d.js
-
-// @type_id values for rendering
-const $R2D_TRIANGLE = 1;
-const $R2D_QUAD     = 2;
-const $R2D_LINE     = 3;
-const $R2D_IMAGE    = 4;
-const $R2D_SPRITE   = 5;
-const $R2D_TEXT     = 6;
-
+// ruby2d.js
 
 function on_key(e) {
 
@@ -104,148 +95,162 @@ function render() {
   var objects = #{$R2D_WINDOW.objects};
 
   for (var i = 0; i < objects.length; i++) {
-
     var el = objects[i];
-
-    switch (el.type_id) {
-
-      case $R2D_TRIANGLE:
-
-        S2D.DrawTriangle(
-          el.x1, el.y1, el.c1.r, el.c1.g, el.c1.b, el.c1.a,
-          el.x2, el.y2, el.c2.r, el.c2.g, el.c2.b, el.c2.a,
-          el.x3, el.y3, el.c3.r, el.c3.g, el.c3.b, el.c3.a
-        );
-        break;
-
-      case $R2D_QUAD:
-        S2D.DrawQuad(
-          el.x1, el.y1, el.c1.r, el.c1.g, el.c1.b, el.c1.a,
-          el.x2, el.y2, el.c2.r, el.c2.g, el.c2.b, el.c2.a,
-          el.x3, el.y3, el.c3.r, el.c3.g, el.c3.b, el.c3.a,
-          el.x4, el.y4, el.c4.r, el.c4.g, el.c4.b, el.c4.a
-        );
-        break;
-
-      case $R2D_LINE:
-        S2D.DrawLine(
-          el.x1, el.y1, el.x2, el.y2, el.width,
-          el.c1.r, el.c1.g, el.c1.b, el.c1.a,
-          el.c2.r, el.c2.g, el.c2.b, el.c2.a,
-          el.c3.r, el.c3.g, el.c3.b, el.c3.a,
-          el.c4.r, el.c4.g, el.c4.b, el.c4.a
-        );
-        break;
-
-      case $R2D_IMAGE:
-        el.data.x = el.x;
-        el.data.y = el.y;
-
-        if (el.width  != Opal.nil) el.data.width  = el.width;
-        if (el.height != Opal.nil) el.data.height = el.height;
-
-        el.data.color.r = el.color.r;
-        el.data.color.g = el.color.g;
-        el.data.color.b = el.color.b;
-        el.data.color.a = el.color.a;
-
-        S2D.DrawImage(el.data);
-        break;
-
-      case $R2D_SPRITE:
-        el.data.x = el.x;
-        el.data.y = el.y;
-
-        S2D.ClipSprite(
-          el.data,
-          el.clip_x,
-          el.clip_y,
-          el.clip_w,
-          el.clip_h
-        );
-
-        S2D.DrawSprite(el.data);
-        break;
-
-      case $R2D_TEXT:
-        el.data.x = el.x;
-        el.data.y = el.y;
-
-        el.data.color.r = el.color.r;
-        el.data.color.g = el.color.g;
-        el.data.color.b = el.color.b;
-        el.data.color.a = el.color.a;
-
-        S2D.DrawText(el.data);
-        break;
-    }
-
+    el['$ext_render']();
   }
-}`
+}
+`
 
 
 module Ruby2D
+  class Triangle
+    def ext_render
+      `S2D.DrawTriangle(
+        #{self}.x1, #{self}.y1, #{self}.c1.r, #{self}.c1.g, #{self}.c1.b, #{self}.c1.a,
+        #{self}.x2, #{self}.y2, #{self}.c2.r, #{self}.c2.g, #{self}.c2.b, #{self}.c2.a,
+        #{self}.x3, #{self}.y3, #{self}.c3.r, #{self}.c3.g, #{self}.c3.b, #{self}.c3.a
+      );`
+    end
+  end
+
+  class Quad
+    def ext_render
+      `S2D.DrawQuad(
+        #{self}.x1, #{self}.y1, #{self}.c1.r, #{self}.c1.g, #{self}.c1.b, #{self}.c1.a,
+        #{self}.x2, #{self}.y2, #{self}.c2.r, #{self}.c2.g, #{self}.c2.b, #{self}.c2.a,
+        #{self}.x3, #{self}.y3, #{self}.c3.r, #{self}.c3.g, #{self}.c3.b, #{self}.c3.a,
+        #{self}.x4, #{self}.y4, #{self}.c4.r, #{self}.c4.g, #{self}.c4.b, #{self}.c4.a
+      );`
+    end
+  end
+
+  class Line
+    def ext_render
+      `S2D.DrawLine(
+        #{self}.x1, #{self}.y1, #{self}.x2, #{self}.y2, #{self}.width,
+        #{self}.c1.r, #{self}.c1.g, #{self}.c1.b, #{self}.c1.a,
+        #{self}.c2.r, #{self}.c2.g, #{self}.c2.b, #{self}.c2.a,
+        #{self}.c3.r, #{self}.c3.g, #{self}.c3.b, #{self}.c3.a,
+        #{self}.c4.r, #{self}.c4.g, #{self}.c4.b, #{self}.c4.a
+      );`
+    end
+  end
+
   class Image
-    def ext_image_init(path)
-      `#{self}.data = S2D.CreateImage(path, function() {
+    def ext_init(path)
+      `
+      #{self}.data = S2D.CreateImage(path, function() {
         if (#{@width} == Opal.nil) {
           #{@width} = #{self}.data.width;
         }
         if (#{@height} == Opal.nil) {
           #{@height} = #{self}.data.height;
         }
-      });`
+      });
+      `
+    end
+
+    def ext_render
+      `
+      #{self}.data.x = #{self}.x;
+      #{self}.data.y = #{self}.y;
+
+      if (#{self}.width  != Opal.nil) #{self}.data.width  = #{self}.width;
+      if (#{self}.height != Opal.nil) #{self}.data.height = #{self}.height;
+
+      #{self}.data.color.r = #{self}.color.r;
+      #{self}.data.color.g = #{self}.color.g;
+      #{self}.data.color.b = #{self}.color.b;
+      #{self}.data.color.a = #{self}.color.a;
+
+      S2D.DrawImage(#{self}.data);
+      `
     end
   end
 
   class Sprite
-    def ext_sprite_init(path)
+    def ext_init(path)
       `#{self}.data = S2D.CreateSprite(path);`
+    end
+
+    def ext_render
+      `
+      #{self}.data.x = #{self}.x;
+      #{self}.data.y = #{self}.y;
+
+      S2D.ClipSprite(
+        #{self}.data,
+        #{self}.clip_x,
+        #{self}.clip_y,
+        #{self}.clip_w,
+        #{self}.clip_h
+      );
+
+      S2D.DrawSprite(#{self}.data);
+      `
     end
   end
 
   class Text
-    def ext_text_init
-      `#{self}.data = S2D.CreateText(#{self}.font, #{self}.text, #{self}.size);`
-      @width  = `#{self}.data.width;`
-      @height = `#{self}.data.height;`
+    def ext_init
+      `
+      #{self}.data = S2D.CreateText(#{self}.font, #{self}.text, #{self}.size);
+      #{@width}  = #{self}.data.width;
+      #{@height} = #{self}.data.height;
+      `
     end
 
-    def ext_text_set(msg)
-      `S2D.SetText(#{self}.data, #{msg});`
-      @width  = `#{self}.data.width;`
-      @height = `#{self}.data.height;`
+    def ext_set(msg)
+      `
+      S2D.SetText(#{self}.data, #{msg});
+      #{@width}  = #{self}.data.width;
+      #{@height} = #{self}.data.height;
+      `
+    end
+
+    def ext_render
+      `
+      #{self}.data.x = #{self}.x;
+      #{self}.data.y = #{self}.y;
+
+      #{self}.data.color.r = #{self}.color.r;
+      #{self}.data.color.g = #{self}.color.g;
+      #{self}.data.color.b = #{self}.color.b;
+      #{self}.data.color.a = #{self}.color.a;
+
+      S2D.DrawText(#{self}.data);
+      `
     end
   end
 
   class Sound
-    def ext_sound_init(path)
+    def ext_init(path)
       `#{self}.data = S2D.CreateSound(path);`
     end
 
-    def ext_sound_play
+    def ext_play
       `S2D.PlaySound(#{self}.data);`
     end
   end
 
   class Music
-    def ext_music_init(path)
+    def ext_init(path)
       `#{self}.data = S2D.CreateMusic(path);`
     end
 
-    def ext_music_play
+    def ext_play
       `S2D.PlayMusic(#{self}.data, #{self}.loop);`
     end
 
-    def ext_music_pause
+    def ext_pause
       `S2D.PauseMusic();`
     end
 
-    def ext_music_resume
+    def ext_resume
       `S2D.ResumeMusic();`
     end
 
-    def ext_music_stop
+    def ext_stop
       `S2D.StopMusic();`
     end
 
@@ -255,7 +260,7 @@ module Ruby2D
   end
 
   class Window
-    def ext_window_show
+    def ext_show
       $R2D_WINDOW = self
 
       `
@@ -277,7 +282,8 @@ module Ruby2D
       win.on_key          = on_key;
       win.on_mouse        = on_mouse;
 
-      S2D.Show(win);`
+      S2D.Show(win);
+      `
     end
   end
 end

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -89,14 +89,6 @@
   #define r_char_to_sym(str)  ID2SYM(rb_intern(str))
 #endif
 
-// @type_id values for rendering
-#define R2D_TRIANGLE 1
-#define R2D_QUAD     2
-#define R2D_LINE     3
-#define R2D_IMAGE    4
-#define R2D_SPRITE   5
-#define R2D_TEXT     6
-
 // Create the MRuby context
 #if MRUBY
   static mrb_state *mrb;
@@ -161,15 +153,146 @@ static R_VAL file_exists(mrb_state* mrb, R_VAL self) {
 
 
 /*
- * Ruby2D::Image#init
+ * Ruby2D::Triangle#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_triangle_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_triangle_ext_render(R_VAL self) {
+#endif
+  R_VAL c1 = r_iv_get(self, "@c1");
+  R_VAL c2 = r_iv_get(self, "@c2");
+  R_VAL c3 = r_iv_get(self, "@c3");
+
+  S2D_DrawTriangle(
+    NUM2DBL(r_iv_get(self, "@x1")),
+    NUM2DBL(r_iv_get(self, "@y1")),
+    NUM2DBL(r_iv_get(c1, "@r")),
+    NUM2DBL(r_iv_get(c1, "@g")),
+    NUM2DBL(r_iv_get(c1, "@b")),
+    NUM2DBL(r_iv_get(c1, "@a")),
+
+    NUM2DBL(r_iv_get(self, "@x2")),
+    NUM2DBL(r_iv_get(self, "@y2")),
+    NUM2DBL(r_iv_get(c2, "@r")),
+    NUM2DBL(r_iv_get(c2, "@g")),
+    NUM2DBL(r_iv_get(c2, "@b")),
+    NUM2DBL(r_iv_get(c2, "@a")),
+
+    NUM2DBL(r_iv_get(self, "@x3")),
+    NUM2DBL(r_iv_get(self, "@y3")),
+    NUM2DBL(r_iv_get(c3, "@r")),
+    NUM2DBL(r_iv_get(c3, "@g")),
+    NUM2DBL(r_iv_get(c3, "@b")),
+    NUM2DBL(r_iv_get(c3, "@a"))
+  );
+
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Quad#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_quad_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_quad_ext_render(R_VAL self) {
+#endif
+  R_VAL c1 = r_iv_get(self, "@c1");
+  R_VAL c2 = r_iv_get(self, "@c2");
+  R_VAL c3 = r_iv_get(self, "@c3");
+  R_VAL c4 = r_iv_get(self, "@c4");
+
+  S2D_DrawQuad(
+    NUM2DBL(r_iv_get(self, "@x1")),
+    NUM2DBL(r_iv_get(self, "@y1")),
+    NUM2DBL(r_iv_get(c1, "@r")),
+    NUM2DBL(r_iv_get(c1, "@g")),
+    NUM2DBL(r_iv_get(c1, "@b")),
+    NUM2DBL(r_iv_get(c1, "@a")),
+
+    NUM2DBL(r_iv_get(self, "@x2")),
+    NUM2DBL(r_iv_get(self, "@y2")),
+    NUM2DBL(r_iv_get(c2, "@r")),
+    NUM2DBL(r_iv_get(c2, "@g")),
+    NUM2DBL(r_iv_get(c2, "@b")),
+    NUM2DBL(r_iv_get(c2, "@a")),
+
+    NUM2DBL(r_iv_get(self, "@x3")),
+    NUM2DBL(r_iv_get(self, "@y3")),
+    NUM2DBL(r_iv_get(c3, "@r")),
+    NUM2DBL(r_iv_get(c3, "@g")),
+    NUM2DBL(r_iv_get(c3, "@b")),
+    NUM2DBL(r_iv_get(c3, "@a")),
+
+    NUM2DBL(r_iv_get(self, "@x4")),
+    NUM2DBL(r_iv_get(self, "@y4")),
+    NUM2DBL(r_iv_get(c4, "@r")),
+    NUM2DBL(r_iv_get(c4, "@g")),
+    NUM2DBL(r_iv_get(c4, "@b")),
+    NUM2DBL(r_iv_get(c4, "@a"))
+  );
+
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Line#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_line_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_line_ext_render(R_VAL self) {
+#endif
+  R_VAL c1 = r_iv_get(self, "@c1");
+  R_VAL c2 = r_iv_get(self, "@c2");
+  R_VAL c3 = r_iv_get(self, "@c3");
+  R_VAL c4 = r_iv_get(self, "@c4");
+
+  S2D_DrawLine(
+    NUM2DBL(r_iv_get(self, "@x1")),
+    NUM2DBL(r_iv_get(self, "@y1")),
+    NUM2DBL(r_iv_get(self, "@x2")),
+    NUM2DBL(r_iv_get(self, "@y2")),
+    NUM2DBL(r_iv_get(self, "@width")),
+
+    NUM2DBL(r_iv_get(c1, "@r")),
+    NUM2DBL(r_iv_get(c1, "@g")),
+    NUM2DBL(r_iv_get(c1, "@b")),
+    NUM2DBL(r_iv_get(c1, "@a")),
+
+    NUM2DBL(r_iv_get(c2, "@r")),
+    NUM2DBL(r_iv_get(c2, "@g")),
+    NUM2DBL(r_iv_get(c2, "@b")),
+    NUM2DBL(r_iv_get(c2, "@a")),
+
+    NUM2DBL(r_iv_get(c3, "@r")),
+    NUM2DBL(r_iv_get(c3, "@g")),
+    NUM2DBL(r_iv_get(c3, "@b")),
+    NUM2DBL(r_iv_get(c3, "@a")),
+
+    NUM2DBL(r_iv_get(c4, "@r")),
+    NUM2DBL(r_iv_get(c4, "@g")),
+    NUM2DBL(r_iv_get(c4, "@b")),
+    NUM2DBL(r_iv_get(c4, "@a"))
+  );
+
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Image#ext_init
  * Initialize image structure data
  */
 #if MRUBY
-static R_VAL ruby2d_image_init(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_image_ext_init(mrb_state* mrb, R_VAL self) {
   mrb_value path;
   mrb_get_args(mrb, "o", &path);
 #else
-static R_VAL ruby2d_image_init(R_VAL self, R_VAL path) {
+static R_VAL ruby2d_image_ext_init(R_VAL self, R_VAL path) {
 #endif
   sprintf(S2D_msg, "Init image: %s", RSTRING_PTR(path));
   S2D_Log(S2D_msg, S2D_INFO);
@@ -183,6 +306,37 @@ static R_VAL ruby2d_image_init(R_VAL self, R_VAL path) {
   r_iv_set(self, "@height", r_test(h) ? h : INT2NUM(img->height));
 
   r_iv_set(self, "@data", r_data_wrap_struct(image, img));
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Image#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_image_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_image_ext_render(R_VAL self) {
+#endif
+  S2D_Image *img;
+  r_data_get_struct(self, "@data", &image_data_type, S2D_Image, img);
+
+  img->x = NUM2DBL(r_iv_get(self, "@x"));
+  img->y = NUM2DBL(r_iv_get(self, "@y"));
+
+  R_VAL w = r_iv_get(self, "@width");
+  R_VAL h = r_iv_get(self, "@height");
+  if (r_test(w)) img->width  = NUM2INT(w);
+  if (r_test(h)) img->height = NUM2INT(h);
+
+  R_VAL c = r_iv_get(self, "@color");
+  img->color.r = NUM2DBL(r_iv_get(c, "@r"));
+  img->color.g = NUM2DBL(r_iv_get(c, "@g"));
+  img->color.b = NUM2DBL(r_iv_get(c, "@b"));
+  img->color.a = NUM2DBL(r_iv_get(c, "@a"));
+
+  S2D_DrawImage(img);
+
   return R_NIL;
 }
 
@@ -203,20 +357,48 @@ static void free_image(S2D_Image *img) {
 
 
 /*
- * Ruby2D::Sprite#init
+ * Ruby2D::Sprite#ext_init
  * Initialize sprite structure data
  */
 #if MRUBY
-static R_VAL ruby2d_sprite_init(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_sprite_ext_init(mrb_state* mrb, R_VAL self) {
   mrb_value path;
   mrb_get_args(mrb, "o", &path);
 #else
-static R_VAL ruby2d_sprite_init(R_VAL self, R_VAL path) {
+static R_VAL ruby2d_sprite_ext_init(R_VAL self, R_VAL path) {
 #endif
   sprintf(S2D_msg, "Init sprite: %s", RSTRING_PTR(path));
   S2D_Log(S2D_msg, S2D_INFO);
   S2D_Sprite *spr = S2D_CreateSprite(RSTRING_PTR(path));
   r_iv_set(self, "@data", r_data_wrap_struct(sprite, spr));
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Sprite#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_sprite_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_sprite_ext_render(R_VAL self) {
+#endif
+  S2D_Sprite *spr;
+  r_data_get_struct(self, "@data", &sprite_data_type, S2D_Sprite, spr);
+
+  spr->x = NUM2DBL(r_iv_get(self, "@x"));
+  spr->y = NUM2DBL(r_iv_get(self, "@y"));
+
+  S2D_ClipSprite(
+    spr,
+    NUM2INT(r_iv_get(self, "@clip_x")),
+    NUM2INT(r_iv_get(self, "@clip_y")),
+    NUM2INT(r_iv_get(self, "@clip_w")),
+    NUM2INT(r_iv_get(self, "@clip_h"))
+  );
+
+  S2D_DrawSprite(spr);
+
   return R_NIL;
 }
 
@@ -237,13 +419,13 @@ static void free_sprite(S2D_Sprite *spr) {
 
 
 /*
- * Ruby2D::Text#init
+ * Ruby2D::Text#ext_init
  * Initialize text structure data
  */
 #if MRUBY
-static R_VAL ruby2d_text_init(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_text_ext_init(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_text_init(R_VAL self) {
+static R_VAL ruby2d_text_ext_init(R_VAL self) {
 #endif
   sprintf(S2D_msg, "Init text: %s", RSTRING_PTR(r_iv_get(self, "@text")));
   S2D_Log(S2D_msg, S2D_INFO);
@@ -263,14 +445,14 @@ static R_VAL ruby2d_text_init(R_VAL self) {
 
 
 /*
- * Ruby2D::Text#ext_text_set
+ * Ruby2D::Text#ext_set
  */
 #if MRUBY
-static R_VAL ruby2d_text_set(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_text_ext_set(mrb_state* mrb, R_VAL self) {
   mrb_value text;
   mrb_get_args(mrb, "o", &text);
 #else
-static R_VAL ruby2d_text_set(R_VAL self, R_VAL text) {
+static R_VAL ruby2d_text_ext_set(R_VAL self, R_VAL text) {
 #endif
   S2D_Text *txt;
   r_data_get_struct(self, "@data", &text_data_type, S2D_Text, txt);
@@ -279,6 +461,32 @@ static R_VAL ruby2d_text_set(R_VAL self, R_VAL text) {
 
   r_iv_set(self, "@width", INT2NUM(txt->width));
   r_iv_set(self, "@height", INT2NUM(txt->height));
+
+  return R_NIL;
+}
+
+
+/*
+ * Ruby2D::Text#ext_render
+ */
+#if MRUBY
+static R_VAL ruby2d_text_ext_render(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_text_ext_render(R_VAL self) {
+#endif
+  S2D_Text *txt;
+  r_data_get_struct(self, "@data", &text_data_type, S2D_Text, txt);
+
+  txt->x = NUM2DBL(r_iv_get(self, "@x"));
+  txt->y = NUM2DBL(r_iv_get(self, "@y"));
+
+  R_VAL c = r_iv_get(self, "@color");
+  txt->color.r = NUM2DBL(r_iv_get(c, "@r"));
+  txt->color.g = NUM2DBL(r_iv_get(c, "@g"));
+  txt->color.b = NUM2DBL(r_iv_get(c, "@b"));
+  txt->color.a = NUM2DBL(r_iv_get(c, "@a"));
+
+  S2D_DrawText(txt);
 
   return R_NIL;
 }
@@ -300,15 +508,15 @@ static void free_text(S2D_Text *txt) {
 
 
 /*
- * Ruby2D::Sound#init
+ * Ruby2D::Sound#ext_init
  * Initialize sound structure data
  */
 #if MRUBY
-static R_VAL ruby2d_sound_init(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_sound_ext_init(mrb_state* mrb, R_VAL self) {
   mrb_value path;
   mrb_get_args(mrb, "o", &path);
 #else
-static R_VAL ruby2d_sound_init(R_VAL self, R_VAL path) {
+static R_VAL ruby2d_sound_ext_init(R_VAL self, R_VAL path) {
 #endif
   sprintf(S2D_msg, "Init sound: %s", RSTRING_PTR(path));
   S2D_Log(S2D_msg, S2D_INFO);
@@ -319,12 +527,12 @@ static R_VAL ruby2d_sound_init(R_VAL self, R_VAL path) {
 
 
 /*
- * Ruby2D::Sound#play
+ * Ruby2D::Sound#ext_play
  */
 #if MRUBY
-static R_VAL ruby2d_sound_play(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_sound_ext_play(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_sound_play(R_VAL self) {
+static R_VAL ruby2d_sound_ext_play(R_VAL self) {
 #endif
   S2D_Sound *snd;
   r_data_get_struct(self, "@data", &sound_data_type, S2D_Sound, snd);
@@ -349,15 +557,15 @@ static void free_sound(S2D_Sound *snd) {
 
 
 /*
- * Ruby2D::Music#init
+ * Ruby2D::Music#ext_init
  * Initialize music structure data
  */
 #if MRUBY
-static R_VAL ruby2d_music_init(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_init(mrb_state* mrb, R_VAL self) {
   mrb_value path;
   mrb_get_args(mrb, "o", &path);
 #else
-static R_VAL ruby2d_music_init(R_VAL self, R_VAL path) {
+static R_VAL ruby2d_music_ext_init(R_VAL self, R_VAL path) {
 #endif
   sprintf(S2D_msg, "Init music: %s", RSTRING_PTR(path));
   S2D_Log(S2D_msg, S2D_INFO);
@@ -368,12 +576,12 @@ static R_VAL ruby2d_music_init(R_VAL self, R_VAL path) {
 
 
 /*
- * Ruby2D::Music#play
+ * Ruby2D::Music#ext_play
  */
 #if MRUBY
-static R_VAL ruby2d_music_play(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_play(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_music_play(R_VAL self) {
+static R_VAL ruby2d_music_ext_play(R_VAL self) {
 #endif
   S2D_Music *mus;
   r_data_get_struct(self, "@data", &music_data_type, S2D_Music, mus);
@@ -383,12 +591,12 @@ static R_VAL ruby2d_music_play(R_VAL self) {
 
 
 /*
- * Ruby2D::Music#pause
+ * Ruby2D::Music#ext_pause
  */
 #if MRUBY
-static R_VAL ruby2d_music_pause(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_pause(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_music_pause(R_VAL self) {
+static R_VAL ruby2d_music_ext_pause(R_VAL self) {
 #endif
   S2D_PauseMusic();
   return R_NIL;
@@ -396,12 +604,12 @@ static R_VAL ruby2d_music_pause(R_VAL self) {
 
 
 /*
- * Ruby2D::Music#resume
+ * Ruby2D::Music#ext_resume
  */
 #if MRUBY
-static R_VAL ruby2d_music_resume(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_resume(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_music_resume(R_VAL self) {
+static R_VAL ruby2d_music_ext_resume(R_VAL self) {
 #endif
   S2D_ResumeMusic();
   return R_NIL;
@@ -409,12 +617,12 @@ static R_VAL ruby2d_music_resume(R_VAL self) {
 
 
 /*
- * Ruby2D::Music#stop
+ * Ruby2D::Music#ext_stop
  */
 #if MRUBY
-static R_VAL ruby2d_music_stop(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_stop(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_music_stop(R_VAL self) {
+static R_VAL ruby2d_music_ext_stop(R_VAL self) {
 #endif
   S2D_StopMusic();
   return R_NIL;
@@ -422,14 +630,14 @@ static R_VAL ruby2d_music_stop(R_VAL self) {
 
 
 /*
- * Ruby2D::Music#fadeout
+ * Ruby2D::Music#ext_fadeout
  */
 #if MRUBY
-static R_VAL ruby2d_music_fadeout(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_music_ext_fadeout(mrb_state* mrb, R_VAL self) {
   mrb_value ms;
   mrb_get_args(mrb, "o", &ms);
 #else
-static R_VAL ruby2d_music_fadeout(R_VAL self, R_VAL ms) {
+static R_VAL ruby2d_music_ext_fadeout(R_VAL self, R_VAL ms) {
 #endif
   S2D_FadeOutMusic(NUM2INT(ms));
   return R_NIL;
@@ -437,7 +645,7 @@ static R_VAL ruby2d_music_fadeout(R_VAL self, R_VAL ms) {
 
 
 /*
- * Free sound structure attached to Ruby 2D `Sound` class
+ * Free music structure attached to Ruby 2D `Music` class
  */
 #if MRUBY
 static void free_music(mrb_state *mrb, void *p_) {
@@ -596,186 +804,19 @@ static void render() {
 
   // Switch on each object type
   for (int i = 0; i < num_objects; ++i) {
-
     R_VAL el = r_ary_entry(objects, i);
-    int type_id = NUM2INT(r_iv_get(el, "@type_id"));
-
-    // Switch on the object's type_id
-    switch(type_id) {
-
-      case R2D_TRIANGLE: {
-        R_VAL c1 = r_iv_get(el, "@c1");
-        R_VAL c2 = r_iv_get(el, "@c2");
-        R_VAL c3 = r_iv_get(el, "@c3");
-
-        S2D_DrawTriangle(
-          NUM2DBL(r_iv_get(el, "@x1")),
-          NUM2DBL(r_iv_get(el, "@y1")),
-          NUM2DBL(r_iv_get(c1, "@r")),
-          NUM2DBL(r_iv_get(c1, "@g")),
-          NUM2DBL(r_iv_get(c1, "@b")),
-          NUM2DBL(r_iv_get(c1, "@a")),
-
-          NUM2DBL(r_iv_get(el, "@x2")),
-          NUM2DBL(r_iv_get(el, "@y2")),
-          NUM2DBL(r_iv_get(c2, "@r")),
-          NUM2DBL(r_iv_get(c2, "@g")),
-          NUM2DBL(r_iv_get(c2, "@b")),
-          NUM2DBL(r_iv_get(c2, "@a")),
-
-          NUM2DBL(r_iv_get(el, "@x3")),
-          NUM2DBL(r_iv_get(el, "@y3")),
-          NUM2DBL(r_iv_get(c3, "@r")),
-          NUM2DBL(r_iv_get(c3, "@g")),
-          NUM2DBL(r_iv_get(c3, "@b")),
-          NUM2DBL(r_iv_get(c3, "@a"))
-        );
-      }
-      break;
-
-      case R2D_QUAD: {
-        R_VAL c1 = r_iv_get(el, "@c1");
-        R_VAL c2 = r_iv_get(el, "@c2");
-        R_VAL c3 = r_iv_get(el, "@c3");
-        R_VAL c4 = r_iv_get(el, "@c4");
-
-        S2D_DrawQuad(
-          NUM2DBL(r_iv_get(el, "@x1")),
-          NUM2DBL(r_iv_get(el, "@y1")),
-          NUM2DBL(r_iv_get(c1, "@r")),
-          NUM2DBL(r_iv_get(c1, "@g")),
-          NUM2DBL(r_iv_get(c1, "@b")),
-          NUM2DBL(r_iv_get(c1, "@a")),
-
-          NUM2DBL(r_iv_get(el, "@x2")),
-          NUM2DBL(r_iv_get(el, "@y2")),
-          NUM2DBL(r_iv_get(c2, "@r")),
-          NUM2DBL(r_iv_get(c2, "@g")),
-          NUM2DBL(r_iv_get(c2, "@b")),
-          NUM2DBL(r_iv_get(c2, "@a")),
-
-          NUM2DBL(r_iv_get(el, "@x3")),
-          NUM2DBL(r_iv_get(el, "@y3")),
-          NUM2DBL(r_iv_get(c3, "@r")),
-          NUM2DBL(r_iv_get(c3, "@g")),
-          NUM2DBL(r_iv_get(c3, "@b")),
-          NUM2DBL(r_iv_get(c3, "@a")),
-
-          NUM2DBL(r_iv_get(el, "@x4")),
-          NUM2DBL(r_iv_get(el, "@y4")),
-          NUM2DBL(r_iv_get(c4, "@r")),
-          NUM2DBL(r_iv_get(c4, "@g")),
-          NUM2DBL(r_iv_get(c4, "@b")),
-          NUM2DBL(r_iv_get(c4, "@a"))
-        );
-      }
-      break;
-
-      case R2D_LINE: {
-        R_VAL c1 = r_iv_get(el, "@c1");
-        R_VAL c2 = r_iv_get(el, "@c2");
-        R_VAL c3 = r_iv_get(el, "@c3");
-        R_VAL c4 = r_iv_get(el, "@c4");
-
-        S2D_DrawLine(
-          NUM2DBL(r_iv_get(el, "@x1")),
-          NUM2DBL(r_iv_get(el, "@y1")),
-          NUM2DBL(r_iv_get(el, "@x2")),
-          NUM2DBL(r_iv_get(el, "@y2")),
-          NUM2DBL(r_iv_get(el, "@width")),
-
-          NUM2DBL(r_iv_get(c1, "@r")),
-          NUM2DBL(r_iv_get(c1, "@g")),
-          NUM2DBL(r_iv_get(c1, "@b")),
-          NUM2DBL(r_iv_get(c1, "@a")),
-
-          NUM2DBL(r_iv_get(c2, "@r")),
-          NUM2DBL(r_iv_get(c2, "@g")),
-          NUM2DBL(r_iv_get(c2, "@b")),
-          NUM2DBL(r_iv_get(c2, "@a")),
-
-          NUM2DBL(r_iv_get(c3, "@r")),
-          NUM2DBL(r_iv_get(c3, "@g")),
-          NUM2DBL(r_iv_get(c3, "@b")),
-          NUM2DBL(r_iv_get(c3, "@a")),
-
-          NUM2DBL(r_iv_get(c4, "@r")),
-          NUM2DBL(r_iv_get(c4, "@g")),
-          NUM2DBL(r_iv_get(c4, "@b")),
-          NUM2DBL(r_iv_get(c4, "@a"))
-        );
-      }
-      break;
-
-      case R2D_IMAGE: {
-        S2D_Image *img;
-        r_data_get_struct(el, "@data", &image_data_type, S2D_Image, img);
-
-        img->x = NUM2DBL(r_iv_get(el, "@x"));
-        img->y = NUM2DBL(r_iv_get(el, "@y"));
-
-        R_VAL w = r_iv_get(el, "@width");
-        R_VAL h = r_iv_get(el, "@height");
-        if (r_test(w)) img->width  = NUM2INT(w);
-        if (r_test(h)) img->height = NUM2INT(h);
-
-        R_VAL c = r_iv_get(el, "@color");
-        img->color.r = NUM2DBL(r_iv_get(c, "@r"));
-        img->color.g = NUM2DBL(r_iv_get(c, "@g"));
-        img->color.b = NUM2DBL(r_iv_get(c, "@b"));
-        img->color.a = NUM2DBL(r_iv_get(c, "@a"));
-
-        S2D_DrawImage(img);
-      }
-      break;
-
-      case R2D_SPRITE: {
-        S2D_Sprite *spr;
-        r_data_get_struct(el, "@data", &sprite_data_type, S2D_Sprite, spr);
-
-        spr->x = NUM2DBL(r_iv_get(el, "@x"));
-        spr->y = NUM2DBL(r_iv_get(el, "@y"));
-
-        S2D_ClipSprite(
-          spr,
-          NUM2INT(r_iv_get(el, "@clip_x")),
-          NUM2INT(r_iv_get(el, "@clip_y")),
-          NUM2INT(r_iv_get(el, "@clip_w")),
-          NUM2INT(r_iv_get(el, "@clip_h"))
-        );
-
-        S2D_DrawSprite(spr);
-      }
-      break;
-
-      case R2D_TEXT: {
-        S2D_Text *txt;
-        r_data_get_struct(el, "@data", &text_data_type, S2D_Text, txt);
-
-        txt->x = NUM2DBL(r_iv_get(el, "@x"));
-        txt->y = NUM2DBL(r_iv_get(el, "@y"));
-
-        R_VAL c = r_iv_get(el, "@color");
-        txt->color.r = NUM2DBL(r_iv_get(c, "@r"));
-        txt->color.g = NUM2DBL(r_iv_get(c, "@g"));
-        txt->color.b = NUM2DBL(r_iv_get(c, "@b"));
-        txt->color.a = NUM2DBL(r_iv_get(c, "@a"));
-
-        S2D_DrawText(txt);
-      }
-      break;
-    }
+    r_funcall(el, "ext_render", 0);
   }
 }
 
 
 /*
- * Ruby2D::Window#show
+ * Ruby2D::Window#ext_show
  */
 #if MRUBY
-static R_VAL ruby2d_show(mrb_state* mrb, R_VAL self) {
+static R_VAL ruby2d_window_ext_show(mrb_state* mrb, R_VAL self) {
 #else
-static R_VAL ruby2d_show(R_VAL self) {
+static R_VAL ruby2d_window_ext_show(R_VAL self) {
 #endif
   ruby2d_window = self;
 
@@ -831,9 +872,9 @@ static R_VAL ruby2d_show(R_VAL self) {
 
 
 /*
- * Ruby2D::Window#close
+ * Ruby2D::Window#ext_close
  */
-static R_VAL ruby2d_close() {
+static R_VAL ruby2d_window_ext_close() {
   S2D_Close(window);
   return R_NIL;
 }
@@ -865,65 +906,92 @@ void Init_ruby2d() {
   // Ruby2D
   R_CLASS ruby2d_module = r_define_module("Ruby2D");
 
+  // Ruby2D::Triangle
+  R_CLASS ruby2d_triangle_class = r_define_class(ruby2d_module, "Triangle");
+
+  // Ruby2D::Triangle#ext_render
+  r_define_method(ruby2d_triangle_class, "ext_render", ruby2d_triangle_ext_render, r_args_none);
+
+  // Ruby2D::Quad
+  R_CLASS ruby2d_quad_class = r_define_class(ruby2d_module, "Quad");
+
+  // Ruby2D::Quad#ext_render
+  r_define_method(ruby2d_quad_class, "ext_render", ruby2d_quad_ext_render, r_args_none);
+
+  // Ruby2D::Line
+  R_CLASS ruby2d_line_class = r_define_class(ruby2d_module, "Line");
+
+  // Ruby2D::Line#ext_render
+  r_define_method(ruby2d_line_class, "ext_render", ruby2d_line_ext_render, r_args_none);
+
   // Ruby2D::Image
   R_CLASS ruby2d_image_class = r_define_class(ruby2d_module, "Image");
 
-  // Ruby2D::Image#init
-  r_define_method(ruby2d_image_class, "ext_image_init", ruby2d_image_init, r_args_req(1));
+  // Ruby2D::Image#ext_init
+  r_define_method(ruby2d_image_class, "ext_init", ruby2d_image_ext_init, r_args_req(1));
+
+  // Ruby2D::Image#ext_render
+  r_define_method(ruby2d_image_class, "ext_render", ruby2d_image_ext_render, r_args_none);
 
   // Ruby2D::Sprite
   R_CLASS ruby2d_sprite_class = r_define_class(ruby2d_module, "Sprite");
 
-  // Ruby2D::Sprite#init
-  r_define_method(ruby2d_sprite_class, "ext_sprite_init", ruby2d_sprite_init, r_args_req(1));
+  // Ruby2D::Sprite#ext_init
+  r_define_method(ruby2d_sprite_class, "ext_init", ruby2d_sprite_ext_init, r_args_req(1));
+
+  // Ruby2D::Sprite#ext_render
+  r_define_method(ruby2d_sprite_class, "ext_render", ruby2d_sprite_ext_render, r_args_none);
 
   // Ruby2D::Text
   R_CLASS ruby2d_text_class = r_define_class(ruby2d_module, "Text");
 
-  // Ruby2D::Text#init
-  r_define_method(ruby2d_text_class, "ext_text_init", ruby2d_text_init, r_args_none);
+  // Ruby2D::Text#ext_init
+  r_define_method(ruby2d_text_class, "ext_init", ruby2d_text_ext_init, r_args_none);
 
-  // Ruby2D::Text#ext_text_set
-  r_define_method(ruby2d_text_class, "ext_text_set", ruby2d_text_set, r_args_req(1));
+  // Ruby2D::Text#ext_set
+  r_define_method(ruby2d_text_class, "ext_set", ruby2d_text_ext_set, r_args_req(1));
+
+  // Ruby2D::Text#ext_render
+  r_define_method(ruby2d_text_class, "ext_render", ruby2d_text_ext_render, r_args_none);
 
   // Ruby2D::Sound
   R_CLASS ruby2d_sound_class = r_define_class(ruby2d_module, "Sound");
 
-  // Ruby2D::Sound#init
-  r_define_method(ruby2d_sound_class, "ext_sound_init", ruby2d_sound_init, r_args_req(1));
+  // Ruby2D::Sound#ext_init
+  r_define_method(ruby2d_sound_class, "ext_init", ruby2d_sound_ext_init, r_args_req(1));
 
-  // Ruby2D::Sound#play
-  r_define_method(ruby2d_sound_class, "ext_sound_play", ruby2d_sound_play, r_args_none);
+  // Ruby2D::Sound#ext_play
+  r_define_method(ruby2d_sound_class, "ext_play", ruby2d_sound_ext_play, r_args_none);
 
   // Ruby2D::Music
   R_CLASS ruby2d_music_class = r_define_class(ruby2d_module, "Music");
 
-  // Ruby2D::Music#init
-  r_define_method(ruby2d_music_class, "ext_music_init", ruby2d_music_init, r_args_req(1));
+  // Ruby2D::Music#ext_init
+  r_define_method(ruby2d_music_class, "ext_init", ruby2d_music_ext_init, r_args_req(1));
 
-  // Ruby2D::Music#play
-  r_define_method(ruby2d_music_class, "ext_music_play", ruby2d_music_play, r_args_none);
+  // Ruby2D::Music#ext_play
+  r_define_method(ruby2d_music_class, "ext_play", ruby2d_music_ext_play, r_args_none);
 
-  // Ruby2D::Music#pause
-  r_define_method(ruby2d_music_class, "ext_music_pause", ruby2d_music_pause, r_args_none);
+  // Ruby2D::Music#ext_pause
+  r_define_method(ruby2d_music_class, "ext_pause", ruby2d_music_ext_pause, r_args_none);
 
-  // Ruby2D::Music#resume
-  r_define_method(ruby2d_music_class, "ext_music_resume", ruby2d_music_resume, r_args_none);
+  // Ruby2D::Music#ext_resume
+  r_define_method(ruby2d_music_class, "ext_resume", ruby2d_music_ext_resume, r_args_none);
 
-  // Ruby2D::Music#stop
-  r_define_method(ruby2d_music_class, "ext_music_stop", ruby2d_music_stop, r_args_none);
+  // Ruby2D::Music#ext_stop
+  r_define_method(ruby2d_music_class, "ext_stop", ruby2d_music_ext_stop, r_args_none);
 
-  // Ruby2D::Music#fadeout
-  r_define_method(ruby2d_music_class, "ext_music_fadeout", ruby2d_music_fadeout, r_args_req(1));
+  // Ruby2D::Music#ext_fadeout
+  r_define_method(ruby2d_music_class, "ext_fadeout", ruby2d_music_ext_fadeout, r_args_req(1));
 
   // Ruby2D::Window
   R_CLASS ruby2d_window_class = r_define_class(ruby2d_module, "Window");
 
-  // Ruby2D::Window#show
-  r_define_method(ruby2d_window_class, "ext_window_show", ruby2d_show, r_args_none);
+  // Ruby2D::Window#ext_show
+  r_define_method(ruby2d_window_class, "ext_show", ruby2d_window_ext_show, r_args_none);
 
-  // Ruby2D::Window#close
-  r_define_method(ruby2d_window_class, "ext_window_close", ruby2d_close, r_args_none);
+  // Ruby2D::Window#ext_close
+  r_define_method(ruby2d_window_class, "ext_close", ruby2d_window_ext_close, r_args_none);
 
 #if MRUBY
   // Load the Ruby 2D app

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -22,11 +22,9 @@ module Ruby2D
       @width  = opts[:width]  || nil
       @height = opts[:height] || nil
 
-      @type_id = 4
-
       self.color = opts[:color] || 'white'
 
-      ext_image_init(@path)
+      ext_init(@path)
       add
     end
 

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -6,8 +6,6 @@ module Ruby2D
     attr_accessor :x1, :x2, :y1, :y2, :color, :width
 
     def initialize(opts = {})
-      @type_id = 3
-
       @x1 = opts[:x1] || 0
       @y1 = opts[:y1] || 0
       @x2 = opts[:x2] || 100

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -16,27 +16,27 @@ module Ruby2D
 
       @path = path
       @loop = false
-      ext_music_init(path)
+      ext_init(path)
     end
 
     def play
-      ext_music_play
+      ext_play
     end
 
     def pause
-      ext_music_pause
+      ext_pause
     end
 
     def resume
-      ext_music_resume
+      ext_resume
     end
 
     def stop
-      ext_music_stop
+      ext_stop
     end
 
     def fadeout(ms)
-      ext_music_fadeout(ms)
+      ext_fadeout(ms)
     end
   end
 end

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -16,8 +16,6 @@ module Ruby2D
     attr_reader :color
 
     def initialize(opts = {})
-      @type_id = 2
-
       @x1 = opts[:x1] || 0
       @y1 = opts[:y1] || 0
       @x2 = opts[:x2] || 100

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -6,8 +6,6 @@ module Ruby2D
     attr_reader :x, :y, :width, :height
 
     def initialize(opts = {})
-      @type_id = 2
-
       @x      = opts[:x]      || 0
       @y      = opts[:y]      || 0
       @z      = opts[:z]      || 0

--- a/lib/ruby2d/sound.rb
+++ b/lib/ruby2d/sound.rb
@@ -15,11 +15,11 @@ module Ruby2D
       end
 
       @path = path
-      ext_sound_init(path)
+      ext_init(path)
     end
 
     def play
-      ext_sound_play
+      ext_play
     end
 
   end

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -12,7 +12,6 @@ module Ruby2D
       #   raise Error, "Cannot find image file `#{path}`"
       # end
 
-      @type_id = 5
       @x, @y, @path = x, y, path
       @clip_x, @clip_y, @clip_w, @clip_h = 0, 0, 0, 0
       @default = nil
@@ -22,7 +21,7 @@ module Ruby2D
       @current_frame_time = 0
       @z = z
 
-      ext_sprite_init(path)
+      ext_init(path)
       if Module.const_defined? :DSL
         Application.add(self)
       end

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -6,7 +6,6 @@ module Ruby2D
     attr_reader :size
 
     def initialize(opts = {})
-      @type_id = 2
       @x = opts[:x] || 0
       @y = opts[:y] || 0
       @z = opts[:z] || 0

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -8,8 +8,6 @@ module Ruby2D
     attr_reader :text, :size, :width, :height, :font, :color
 
     def initialize(opts = {})
-      @type_id = 6
-
       @x = opts[:x] || 0
       @y = opts[:y] || 0
       @z = opts[:z] || 0
@@ -25,13 +23,13 @@ module Ruby2D
       end
 
       self.color = opts[:color] || 'white'
-      ext_text_init
+      ext_init
       add
     end
 
     def text=(msg)
       @text = msg.to_s
-      ext_text_set(@text)
+      ext_set(@text)
     end
 
     def color=(c)

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -10,8 +10,6 @@ module Ruby2D
     attr_reader :color, :type_id
 
     def initialize(opts= {})
-      @type_id = 1
-
       @x1 = opts[:x1] || 50
       @y1 = opts[:y1] || 0
       @x2 = opts[:x2] || 100

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -228,11 +228,11 @@ module Ruby2D
     end
 
     def show
-      ext_window_show
+      ext_show
     end
 
     def close
-      ext_window_close
+      ext_close
     end
 
     private


### PR DESCRIPTION
Continuing our conversation about removing `type_id` as unnecessary from ruby code, an idea came to me: Why do we assign values to classess, and then call specific logic based on those assigned values, if we can be good object-oriented programmers, and simply dispatch expected logic to those classess. So With a little bit experimentation I did that for js extension (since I can handle js, unlike c). This actually works very well, and I would say it simplifies the code. To make the story short:

* Defines `ext_render` method for all renderable classess
* Removes the need for `@type_id` instance variable
* Inside render loop, simply calls `ext_render` on each object.

Additionally, I might say, this makes the code easier to understand, which in the long run might pave the way for implementation of more complex features, or for performance improvements. I am already wondering if some of those render methods might be organised in more efficient manner; )

@blacktm  what do you think?