### PR TITLE
Add rake as development dependency

### DIFF
--- a/ruby2d.gemspec
+++ b/ruby2d.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
   s.add_dependency 'opal', '~> 0.10'
+  s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec', '~> 3.7'
 
   s.files = Dir.glob('lib/**/*') +


### PR DESCRIPTION
Cloning the repo, installing the gems via `bundle install` and running `be rake -T` yields
the following error:

```bash
bundler: failed to load command: rake (/Users/user/.rbenv/versions/2.4.1/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile?
  /Users/user/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/rubygems_integration.rb:458:in `block in replace_bin_path'
  /Users/user/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/rubygems_integration.rb:478:in `block in replace_bin_path'
  /Users/user/.rbenv/versions/2.4.1/bin/rake:22:in `<top (required)>'
```

Adding rake as dependency fixes this problem

However, I'm not sure that it's ok to not specify a version for `rake`. I'm not sure which one should be specified, though.