### PR TITLE
Remove requiring of ruby2d from ruby2d

### DIFF
--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -16,7 +16,6 @@ require 'ruby2d/sprite'
 require 'ruby2d/text'
 require 'ruby2d/sound'
 require 'ruby2d/music'
-require 'ruby2d/ruby2d'  # load native extension
 
 include Ruby2D
 extend  Ruby2D::DSL


### PR DESCRIPTION
This fixes the following error, when running rake spec

```bash
LoadError:
  cannot load such file -- ruby2d/ruby2d
```
