### PR TITLE
Add window method to DSL to allow fetching window attributes directly.

### DIFF
--- a/lib/ruby2d/application.rb
+++ b/lib/ruby2d/application.rb
@@ -4,6 +4,10 @@ module Ruby2D::Application
   class << self
     @@window = Ruby2D::Window.new
 
+    def window
+      @@window
+    end
+
     def get(sym)
       @@window.get(sym)
     end

--- a/lib/ruby2d/dsl.rb
+++ b/lib/ruby2d/dsl.rb
@@ -1,6 +1,10 @@
 # dsl.rb
 
 module Ruby2D::DSL
+  def window
+    Application.window
+  end
+
   def get(sym)
     Application.get(sym)
   end

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -3,7 +3,7 @@
 module Ruby2D
   class Window
 
-    attr_reader :objects
+    attr_reader :objects, :width, :height
     attr_accessor :mouse_x, :mouse_y, :frames, :fps
 
     EventDescriptor = Struct.new(:type, :id)


### PR DESCRIPTION
Not sure how you feel about this one, but it feels a little strange to access certain attributes of the window without mentioning the word "window". I added this method as an alias so that I could make my code a little more readable. For example:

```ruby
if sprite.y > get(:height)
# vs...
if sprite.y > window.height
```

Another example:
```ruby
game_over_text.x = (get(:width) / 2) - (game_over_text.width / 2)
# vs...
game_over_text.x = (window.width / 2) - (game_over_text.width / 2)
```

To me, the use of `window.width` is more readable. What do you think?