### PR TITLE
Enable setting and getting custom fps_cap

### DIFF
--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -919,6 +919,7 @@ static R_VAL ruby2d_window_ext_show(R_VAL self) {
   char *title = RSTRING_PTR(r_iv_get(self, "@title"));
   int width   = NUM2INT(r_iv_get(self, "@width"));
   int height  = NUM2INT(r_iv_get(self, "@height"));
+  int fps_cap = NUM2INT(r_iv_get(self, "@fps_cap"));
   int flags   = 0;
 
   // Get window flags
@@ -951,6 +952,7 @@ static R_VAL ruby2d_window_ext_show(R_VAL self) {
 
   window->viewport.width  = viewport_width;
   window->viewport.height = viewport_height;
+  window->fps_cap         = fps_cap;
   window->on_key          = on_key;
   window->on_mouse        = on_mouse;
   window->on_controller   = on_controller;

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -25,9 +25,9 @@ module Ruby2D
       @fullscreen = false
       @highdpi    = false
       @frames     = 0
-      @fps_cap    = args[:fps]    || 60
+      @fps_cap    = args[:fps_cap] || 60
       @fps        = @fps_cap
-      @vsync      = args[:vsync]  || true
+      @vsync      = args[:vsync]   || true
       @mouse_x, @mouse_y = 0, 0
       @objects    = []
       @event_key  = 0
@@ -77,6 +77,7 @@ module Ruby2D
       when :highdpi;         @highdpi
       when :frames;          @frames
       when :fps;             @fps
+      when :fps_cap;         @fps_cap
       when :mouse_x;         @mouse_x
       when :mouse_y;         @mouse_y
       when :diagnostics;     @diagnostics
@@ -91,6 +92,7 @@ module Ruby2D
       end
       @width           = opts[:width]           || @width
       @height          = opts[:height]          || @height
+      @fps_cap         = opts[:fps_cap]         || @fps_cap
       @viewport_width  = opts[:viewport_width]  || @viewport_width
       @viewport_height = opts[:viewport_height] || @viewport_height
       @resizable       = opts[:resizable]       || @resizable


### PR DESCRIPTION
This resolves #108 by adding `:fps_cap` to the `Window.get` and `Window.set` methods. I also changed the option in `Window.new` from `:fps` to `:fps_cap` for the sake of consistency. It seems like a safe change since `Window.new` is not passed options anywhere in the current  code-base. 