### PR TITLE
Implements volume control to Music objects

### DIFF
--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -253,7 +253,7 @@ module Ruby2D
     def ext_stop
       `S2D.StopMusic();`
     end
-    
+
     def ext_music_fadeout(ms)
       `S2D.FadeOutMusic(ms);`
     end

--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -254,6 +254,11 @@ module Ruby2D
       `S2D.StopMusic();`
     end
 
+    def ext_volume(percentage = -1)
+      vol = (percentage/100.0)*128
+      `Mix_VolumeMusic(vol);`
+    end
+
     def ext_music_fadeout(ms)
       `S2D.FadeOutMusic(ms);`
     end

--- a/ext/ruby2d/ruby2d-opal.rb
+++ b/ext/ruby2d/ruby2d-opal.rb
@@ -253,12 +253,7 @@ module Ruby2D
     def ext_stop
       `S2D.StopMusic();`
     end
-
-    def ext_volume(percentage = -1)
-      vol = (percentage/100.0)*128
-      `Mix_VolumeMusic(vol);`
-    end
-
+    
     def ext_music_fadeout(ms)
       `S2D.FadeOutMusic(ms);`
     end

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -675,8 +675,8 @@ static R_VAL ruby2d_music_ext_volume(mrb_state* mrb, R_VAL self) {
 #else
 static R_VAL ruby2d_music_ext_volume(R_VAL self, R_VAL vol) {
 #endif
-  int mix_vol = (FIX2INT(vol) == -1) ? -1 : MIX_MAX_VOLUME * (FIX2INT(vol) / 100.0);
-  return INT2FIX((Mix_VolumeMusic(mix_vol) * 100.0) / MIX_MAX_VOLUME);
+  int mix_vol = NUM2INT(vol) == -1 ? -1 : MIX_MAX_VOLUME * NUM2INT(vol) / 100.0;
+  return INT2NUM(ceil(Mix_VolumeMusic(mix_vol) * 100.0 / MIX_MAX_VOLUME));
 }
 
 
@@ -1144,11 +1144,8 @@ void Init_ruby2d() {
   // Ruby2D::Music#ext_stop
   r_define_method(ruby2d_music_class, "ext_stop", ruby2d_music_ext_stop, r_args_none);
 
-  // Ruby2D::Music#ext_volume
-  r_define_method(ruby2d_music_class, "ext_volume", ruby2d_music_ext_volume, r_args_req(1));
-
-  // Ruby2D::Music#self.volume
-  r_define_class_method(ruby2d_music_class, "volume", ruby2d_music_ext_volume, r_args_req(1));
+  // Ruby2D::Music#self.ext_volume
+  r_define_class_method(ruby2d_music_class, "ext_volume", ruby2d_music_ext_volume, r_args_req(1));
 
   // Ruby2D::Music#ext_fadeout
   r_define_method(ruby2d_music_class, "ext_fadeout", ruby2d_music_ext_fadeout, r_args_req(1));

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -65,6 +65,7 @@
   #define r_define_module(name)  mrb_define_module(mrb, name)
   #define r_define_class(module, name)  mrb_define_class_under(mrb, module, name, mrb->object_class)
   #define r_define_method(class, name, function, args)  mrb_define_method(mrb, class, name, function, args)
+  #define r_define_class_method(class, name, function, args)  mrb_define_class_method(mrb, class, name, function, args)
   #define r_args_none  (MRB_ARGS_NONE())
   #define r_args_req(n)  MRB_ARGS_REQ(n)
   // Helpers
@@ -87,6 +88,7 @@
   #define r_define_module(name)  rb_define_module(name)
   #define r_define_class(module, name)  rb_define_class_under(module, name, rb_cObject)
   #define r_define_method(class, name, function, args)  rb_define_method(class, name, function, args)
+  #define r_define_class_method(class, name, function, args)  rb_define_singleton_method(class, name, function, args)
   #define r_args_none  0
   #define r_args_req(n)  n
   // Helpers
@@ -1143,6 +1145,9 @@ void Init_ruby2d() {
 
   // Ruby2D::Music#ext_volume
   r_define_method(ruby2d_music_class, "ext_volume", ruby2d_music_ext_volume, r_args_req(1));
+
+  // Ruby2D::Music#self.volume
+  r_define_class_method(ruby2d_music_class, "volume", ruby2d_music_ext_volume, r_args_req(1));
 
   // Ruby2D::Music#ext_fadeout
   r_define_method(ruby2d_music_class, "ext_fadeout", ruby2d_music_ext_fadeout, r_args_req(1));

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -664,6 +664,7 @@ static R_VAL ruby2d_music_ext_stop(R_VAL self) {
   return R_NIL;
 }
 
+
 /*
  * Ruby2D::Music#ext_volume
  */
@@ -674,10 +675,10 @@ static R_VAL ruby2d_music_ext_volume(mrb_state* mrb, R_VAL self) {
 #else
 static R_VAL ruby2d_music_ext_volume(R_VAL self, R_VAL vol) {
 #endif
-  int ret_vol;
-  ret_vol = Mix_VolumeMusic(NUM2INT(vol));
-  return INT2FIX(ret_vol);
+  int mix_vol = (FIX2INT(vol) == -1) ? -1 : MIX_MAX_VOLUME * (FIX2INT(vol) / 100.0);
+  return INT2FIX((Mix_VolumeMusic(mix_vol) * 100.0) / MIX_MAX_VOLUME);
 }
+
 
 /*
  * Ruby2D::Music#ext_fadeout

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -662,6 +662,20 @@ static R_VAL ruby2d_music_ext_stop(R_VAL self) {
   return R_NIL;
 }
 
+/*
+ * Ruby2D::Music#ext_volume
+ */
+#if MRUBY
+static R_VAL ruby2d_music_ext_volume(mrb_state* mrb, R_VAL self) {
+  mrb_value vol;
+  mrb_get_args(mrb, "o", &vol);
+#else
+static R_VAL ruby2d_music_ext_volume(R_VAL self, R_VAL vol) {
+#endif
+  int ret_vol;
+  ret_vol = Mix_VolumeMusic(NUM2INT(vol));
+  return INT2FIX(ret_vol);
+}
 
 /*
  * Ruby2D::Music#ext_fadeout
@@ -1126,6 +1140,9 @@ void Init_ruby2d() {
 
   // Ruby2D::Music#ext_stop
   r_define_method(ruby2d_music_class, "ext_stop", ruby2d_music_ext_stop, r_args_none);
+
+  // Ruby2D::Music#ext_volume
+  r_define_method(ruby2d_music_class, "ext_volume", ruby2d_music_ext_volume, r_args_req(1));
 
   // Ruby2D::Music#ext_fadeout
   r_define_method(ruby2d_music_class, "ext_fadeout", ruby2d_music_ext_fadeout, r_args_req(1));

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -53,7 +53,7 @@ module Ruby2D
 
     # Alias instance methods to class methods
     def volume; Music.volume end
-    def volume=(v); Music.volume = v end
+    def volume=(v); Music.volume=(v) end
 
     # Fade out music over provided milliseconds
     def fadeout(ms)

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -39,9 +39,14 @@ module Ruby2D
       ext_stop
     end
 
-    # Set music volume, 0-100%. If no parameters given, return current volume.
+    # Set music volume, 0-100%. Returns the previous volume setting, in percentage.
+    # If no parameters given, return current volume.
     def volume(percentage = -1)
-      (ext_volume(percentage)/128.0)*100
+      ext_volume(percentage)
+    end
+
+    def self.volume(percentage = -1)
+      ext_volume(percentage)
     end
 
     # Fade out music over provided milliseconds

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -39,15 +39,21 @@ module Ruby2D
       ext_stop
     end
 
-    # Set music volume, 0-100%. Returns the previous volume setting, in percentage.
-    # If no parameters given, return current volume.
-    def volume(percentage = -1)
-      ext_volume(percentage)
+    # Returns the previous volume setting, in percentage
+    def self.volume
+      self.ext_volume(-1)
     end
 
-    def self.volume(percentage = -1)
-      ext_volume(percentage)
+    # Set music volume, 0 to 100%
+    def self.volume=(v)
+      # If a negative value, volume will be 0
+      if v < 0 then v = 0 end
+      self.ext_volume(v)
     end
+
+    # Alias instance methods to class methods
+    def volume; Music.volume end
+    def volume=(v); Music.volume = v end
 
     # Fade out music over provided milliseconds
     def fadeout(ms)

--- a/lib/ruby2d/music.rb
+++ b/lib/ruby2d/music.rb
@@ -39,6 +39,11 @@ module Ruby2D
       ext_stop
     end
 
+    # Set music volume, 0-100%. If no parameters given, return current volume.
+    def volume(percentage = -1)
+      (ext_volume(percentage)/128.0)*100
+    end
+
     # Fade out music over provided milliseconds
     def fadeout(ms)
       ext_fadeout(ms)

--- a/test/audio.rb
+++ b/test/audio.rb
@@ -11,28 +11,39 @@ set width: 300, height: 200, title: "Ruby 2D — Audio"
 snd = Sound.new("#{media}/sound.wav")
 mus = Music.new("#{media}/music.wav")
 
+volume_bar = Rectangle.new(color: 'green', width: 300, height: 50)
+
+on :mouse_down do |event|
+  Music.volume = event.x / Window.width.to_f * 100
+  volume_bar.width = Music.volume / 100.0 * Window.width
+  puts "Music volume: #{Music.volume}%"
+end
+
 on :key_down do |event|
   case event.key
   when 'p'
-    puts "Playing sound..."
+    puts "Playing sound"
     snd.play
   when 'm'
-    puts "Playing music..."
+    puts "Playing music"
     mus.play
+    mus.volume = 100
+    volume_bar.width = Window.width
+    puts "Music volume: #{mus.volume}"
   when 'l'
-    puts "Loop music true..."
+    puts "Looping music"
     mus.loop = true
   when 'a'
-    puts "Pause music..."
+    puts "Music paused"
     mus.pause
   when 'r'
-    puts "Resume music..."
+    puts "Music resumed"
     mus.resume
   when 's'
-    puts "Stop music..."
+    puts "Music stopped"
     mus.stop
   when 'f'
-    puts "fade out music..."
+    puts "Music fading out"
     mus.fadeout 2000
   when 'escape'
     close

--- a/test/music_spec.rb
+++ b/test/music_spec.rb
@@ -6,6 +6,33 @@ RSpec.describe Ruby2D::Music do
     it "raises exception if audio file doesn't exist" do
       expect { Music.new("bad_music.mp3") }.to raise_error(Ruby2D::Error)
     end
+
+    it "creates new music" do
+      Music.new("test/media/music.mp3")
+    end
+  end
+
+  describe "#volume" do
+    it "sets the volume on music instances" do
+      mus = Music.new("test/media/music.mp3")
+      expect(mus.volume).to eq(100)
+      mus.volume = 68
+      expect(mus.volume).to eq(68)
+    end
+
+    it "sets the volume using class methods" do
+      Music.volume = 27
+      expect(Music.volume).to eq(27)
+    end
+
+    it "sets volume to 0 or 100 if outside of range" do
+      Music.volume = 234
+      expect(Music.volume).to eq(100)
+      Music.volume = -312
+      expect(Music.volume).to eq(0)
+      Music.volume = -1
+      expect(Music.volume).to eq(0)
+    end
   end
 
 end


### PR DESCRIPTION
This PR contributes to #115 

Since Simple2D does not have an implementation of the volume control offered in SDL, the native SDL function was used, as suggested by @amicloud.

- The method 'volume' can be called from any ```Music``` object. 
- If no parameters passed, the method returns the current volume of the music. 
- If a number 0-100 is provided, the music volume is adjusted in that percentage. 
- Bigger values will always result in 100% volume and less than 0 values will have the same behavior as not providing any arguments.
