### PR TITLE
Add an assets path variable

### DIFF
--- a/bin/ruby2d
+++ b/bin/ruby2d
@@ -8,8 +8,9 @@ require 'fileutils'
 
 # The Ruby 2D library files
 @lib_files = [
-  'renderable',
+  'colorize',
   'exceptions',
+  'renderable',
   'color',
   'window',
   'dsl',
@@ -24,7 +25,8 @@ require 'fileutils'
   'font',
   'text',
   'sound',
-  'music'
+  'music',
+  '../ruby2d'
 ]
 
 # Debugging command-line flag
@@ -49,14 +51,10 @@ def make_lib
 
   lib_dir = "#{@gem_dir}/lib/ruby2d/"
 
-  lib = ""
+  lib = ''
   @lib_files.each do |f|
     lib << File.read("#{lib_dir + f}.rb") + "\n\n"
   end
-
-  lib << "
-include Ruby2D
-extend  Ruby2D::DSL\n"
 
   File.write('build/lib.rb', lib)
 end

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -155,6 +155,18 @@ double normalize_controller_axis(int val) {
 
 
 /*
+ * Ruby2D#self.ext_base_path
+ */
+#if MRUBY
+static R_VAL ruby2d_ext_base_path(mrb_state* mrb, R_VAL self) {
+#else
+static R_VAL ruby2d_ext_base_path(R_VAL self) {
+#endif
+  return r_str_new(SDL_GetBasePath());
+}
+
+
+/*
  * Ruby2D::Triangle#ext_render
  */
 #if MRUBY
@@ -1068,6 +1080,9 @@ void Init_ruby2d() {
 
   // Ruby2D
   R_CLASS ruby2d_module = r_define_module("Ruby2D");
+
+  // Ruby2D#self.ext_base_path
+  r_define_class_method(ruby2d_module, "ext_base_path", ruby2d_ext_base_path, r_args_none);
 
   // Ruby2D::Triangle
   R_CLASS ruby2d_triangle_class = r_define_class(ruby2d_module, "Triangle");

--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -36,15 +36,21 @@ end
 
 
 module Ruby2D
-  path = Ruby2D.ext_base_path
-  if path.include? '/Contents/Resources/'
-    @assets = path
-  else
-    @assets = './assets'
-  end
+
+  @assets = nil
 
   class << self
-    def assets; @assets end
+    def assets
+      unless @assets
+        if RUBY_ENGINE == 'mruby'
+          @assets = Ruby2D.ext_base_path + 'assets'
+        else
+          @assets = './assets'
+        end
+      end
+      @assets
+    end
+
     def assets=(path); @assets = path end
   end
 end

--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -1,36 +1,53 @@
 # Ruby2D module and native extension loader, adds DSL
 
-require 'ruby2d/colorize'
-require 'ruby2d/exceptions'
-require 'ruby2d/renderable'
-require 'ruby2d/color'
-require 'ruby2d/window'
-require 'ruby2d/dsl'
-require 'ruby2d/quad'
-require 'ruby2d/line'
-require 'ruby2d/circle'
-require 'ruby2d/rectangle'
-require 'ruby2d/square'
-require 'ruby2d/triangle'
-require 'ruby2d/image'
-require 'ruby2d/sprite'
-require 'ruby2d/font'
-require 'ruby2d/text'
-require 'ruby2d/sound'
-require 'ruby2d/music'
+unless RUBY_ENGINE == 'mruby'
+  require 'ruby2d/colorize'
+  require 'ruby2d/exceptions'
+  require 'ruby2d/renderable'
+  require 'ruby2d/color'
+  require 'ruby2d/window'
+  require 'ruby2d/dsl'
+  require 'ruby2d/quad'
+  require 'ruby2d/line'
+  require 'ruby2d/circle'
+  require 'ruby2d/rectangle'
+  require 'ruby2d/square'
+  require 'ruby2d/triangle'
+  require 'ruby2d/image'
+  require 'ruby2d/sprite'
+  require 'ruby2d/font'
+  require 'ruby2d/text'
+  require 'ruby2d/sound'
+  require 'ruby2d/music'
 
-if RUBY_PLATFORM =~ /mingw/
-  # When using the Windows CI AppVeyor
-  if ENV['APPVEYOR']
-    s2d_dll_path = 'C:\msys64\usr\local\bin'
-  # When in a standard MinGW shell
-  else
-    s2d_dll_path = '~/../../usr/local/bin'
+  if RUBY_PLATFORM =~ /mingw/
+    # When using the Windows CI AppVeyor
+    if ENV['APPVEYOR']
+      s2d_dll_path = 'C:\msys64\usr\local\bin'
+    # When in a standard MinGW shell
+    else
+      s2d_dll_path = '~/../../usr/local/bin'
+    end
+    RubyInstaller::Runtime.add_dll_directory(File.expand_path(s2d_dll_path))
   end
-  RubyInstaller::Runtime.add_dll_directory(File.expand_path(s2d_dll_path))
+
+  require 'ruby2d/ruby2d'  # load native extension
 end
 
-require 'ruby2d/ruby2d'  # load native extension
+
+module Ruby2D
+  path = Ruby2D.ext_base_path
+  if path.include? '/Contents/Resources/'
+    @assets = path
+  else
+    @assets = './assets'
+  end
+
+  class << self
+    def assets; @assets end
+    def assets=(path); @assets = path end
+  end
+end
 
 include Ruby2D
 extend  Ruby2D::DSL


### PR DESCRIPTION
Adds `Ruby2D.assets/=`. By default, will resolve to `./assets`. If run in a macOS app bundle, will resolve to `App.app/Contents/Resources/assets`, for example.