### PR TITLE
Color enhancements, fixes, refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 os: osx
-osx_image: xcode10
+osx_image: xcode10.1
 language: ruby
 before_install:
-  - sw_vers
-  - brew update
   - brew tap simple2d/tap
   - brew install simple2d mruby
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ install:
 build: off
 before_test:
   - ruby -v
-  - gem install bundler
   - bundle install
 test_script:
   - rake

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -444,6 +444,12 @@ static R_VAL ruby2d_sprite_ext_render(R_VAL self) {
 
   S2D_RotateSprite(spr, NUM2DBL(r_iv_get(self, "@rotate")), S2D_CENTER);
 
+  R_VAL c = r_iv_get(self, "@color");
+  spr->color.r = NUM2DBL(r_iv_get(c, "@r"));
+  spr->color.g = NUM2DBL(r_iv_get(c, "@g"));
+  spr->color.b = NUM2DBL(r_iv_get(c, "@b"));
+  spr->color.a = NUM2DBL(r_iv_get(c, "@a"));
+
   S2D_ClipSprite(
     spr,
     NUM2INT(r_iv_get(self, "@clip_x")),

--- a/lib/ruby2d/circle.rb
+++ b/lib/ruby2d/circle.rb
@@ -4,8 +4,7 @@ module Ruby2D
   class Circle
     include Renderable
 
-    attr_reader :color
-    attr_accessor :x, :y, :radius, :sectors
+    attr_accessor :radius, :sectors
 
     def initialize(opts = {})
       @x = opts[:x] || 25
@@ -14,11 +13,8 @@ module Ruby2D
       @radius = opts[:radius] || 25
       @sectors = opts[:sectors] || 20
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       add
-    end
-
-    def color=(c)
-      @color = Color.from(c)
     end
 
     def contains?(x, y)

--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -70,6 +70,17 @@ module Ruby2D
       end
     end
 
+    # Return a color set if an array of valid colors
+    def self.set(colors)
+      # If a valid array of colors, return a `Color::Set` with those colors
+      if colors.is_a?(Array) && colors.all? { |el| Color.is_valid? el }
+        Color::Set.new(colors)
+      # Otherwise, return single color
+      else
+        Color.new(colors)
+      end
+    end
+
     # Check if string is a proper hex value
     def self.is_hex?(s)
       # MRuby doesn't support regex, otherwise we'd do:
@@ -87,17 +98,6 @@ module Ruby2D
       c.all? { |el| el.is_a?(Numeric) }
     end
 
-    # Create a color from whatever is provided
-    def self.from(input)
-      # If a valid array of colors, return a `Color::Set` with those colors
-      if input.is_a? Array and input.all? { |el| Color.is_valid? el }
-        Color::Set.new(input)
-      # Otherwise, return single color
-      else
-        Color.new(input)
-      end
-    end
-
     # Convenience methods to alias `opacity` to `@a`
     def opacity; @a end
     def opacity=(opacity); @a = opacity end
@@ -105,7 +105,6 @@ module Ruby2D
     private
 
     # Convert from Fixnum (0..255) to Float (0.0..1.0)
-    #   TODO: Only `Number` is supported in JS
     def to_f(a)
       b = []
       a.each do |n|

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -4,7 +4,7 @@ module Ruby2D
   class Image
     include Renderable
 
-    attr_reader :path, :color
+    attr_reader :path
     attr_accessor :x, :y, :width, :height, :rotate, :data
 
     def initialize(path, opts = {})
@@ -19,12 +19,9 @@ module Ruby2D
       @height = opts[:height] || nil
       @rotate = opts[:rotate] || 0
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       ext_init(@path)
       add
-    end
-
-    def color=(c)
-      @color = Color.new(c)
     end
 
   end

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -4,7 +4,7 @@ module Ruby2D
   class Line
     include Renderable
 
-    attr_accessor :x1, :x2, :y1, :y2, :color, :width
+    attr_accessor :x1, :x2, :y1, :y2
 
     def initialize(opts = {})
       @x1 = opts[:x1] || 0
@@ -14,11 +14,12 @@ module Ruby2D
       @width = opts[:width] || 2
       @z = opts[:z] || 0
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 
     def color=(c)
-      @color = Color.from(c)
+      @color = Color.set(c)
       update_color(@color)
     end
 

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -4,8 +4,6 @@ module Ruby2D
   class Quad
     include Renderable
 
-    attr_reader :color
-
     # Coordinates in clockwise order, starting at top left:
     # x1,y1 == top left
     # x2,y2 == top right
@@ -27,11 +25,12 @@ module Ruby2D
       @y4 = opts[:y4] || 100
       @z  = opts[:z]  || 0
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 
     def color=(c)
-      @color = Color.from(c)
+      @color = Color.set(c)
       update_color(@color)
     end
 

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -3,8 +3,6 @@
 module Ruby2D
   class Rectangle < Quad
 
-    attr_reader :x, :y, :width, :height
-
     def initialize(opts = {})
       @x = opts[:x] || 0
       @y = opts[:y] || 0
@@ -12,6 +10,7 @@ module Ruby2D
       @width = opts[:width] || 200
       @height = opts[:height] || 100
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       update_coords(@x, @y, @width, @height)
       add
     end

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -3,7 +3,7 @@
 module Ruby2D
   module Renderable
 
-    attr_reader :z
+    attr_reader :x, :y, :z, :width, :height, :color
 
     # Set the z position (depth) of the object
     def z=(z)
@@ -26,6 +26,15 @@ module Ruby2D
       end
     end
 
+    # Set the color value
+    def color=(c)
+      @color = Color.new(c)
+    end
+
+    # Allow British English spelling of color
+    def colour; self.color end
+    def colour=(c); self.color = c end
+
     # Allow shortcuts for setting color values
     def r; self.color.r end
     def g; self.color.g end
@@ -38,11 +47,7 @@ module Ruby2D
     def opacity; self.color.opacity end
     def opacity=(val); self.color.opacity = val end
 
-    # Allow British English spelling of color
-    def colour; self.color end
-    def colour=(c); self.color = c end
-
-    # Check if given point is within a rectangle, by default (unless overridden)
+    # Add a contains method stub
     def contains?(x, y)
       x > @x && x < (@x + @width) && y > @y && y < (@y + @height)
     end

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -4,7 +4,6 @@ module Ruby2D
   class Sprite
     include Renderable
 
-    attr_reader :x, :y, :width, :height
     attr_accessor :rotate, :loop, :clip_x, :clip_y, :clip_width, :clip_height, :data
 
     def initialize(path, opts = {})
@@ -22,6 +21,8 @@ module Ruby2D
       @width  = opts[:width]  || nil
       @height = opts[:height] || nil
       @rotate = opts[:rotate] || 0
+      self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
 
       # Flipping status, coordinates, and size, used internally
       @flip = nil

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -11,6 +11,7 @@ module Ruby2D
       @z = opts[:z] || 0
       @width = @height = @size = opts[:size] || 100
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       update_coords(@x, @y, @size, @size)
       add
     end

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -4,7 +4,7 @@ module Ruby2D
   class Text
     include Renderable
 
-    attr_reader :text, :size, :width, :height, :font, :color
+    attr_reader :text, :size, :font
     attr_accessor :x, :y, :rotate, :data
 
     def initialize(text, opts = {})
@@ -14,11 +14,12 @@ module Ruby2D
       @text = text.to_s
       @size = opts[:size] || 20
       @rotate = opts[:rotate] || 0
+      self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       @font = opts[:font] || Font.default
       unless File.exist? @font
         raise Error, "Cannot find font file `#{@font}`"
       end
-      self.color = opts[:color] || 'white'
       ext_init
       add
     end
@@ -26,10 +27,6 @@ module Ruby2D
     def text=(msg)
       @text = msg.to_s
       ext_set(@text)
-    end
-
-    def color=(c)
-      @color = Color.new(c)
     end
 
   end

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -4,7 +4,6 @@ module Ruby2D
   class Triangle
     include Renderable
 
-    attr_reader :color
     attr_accessor :x1, :y1, :c1,
                   :x2, :y2, :c2,
                   :x3, :y3, :c3
@@ -18,11 +17,12 @@ module Ruby2D
       @y3 = opts[:y3] || 100
       @z  = opts[:z]  || 0
       self.color = opts[:color] || 'white'
+      self.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 
     def color=(c)
-      @color = Color.from(c)
+      @color = Color.set(c)
       update_color(@color)
     end
 


### PR DESCRIPTION
Opacity and color can now be set for sprites. Opacity can now also be set when instantiating a new renderable object. `Color.from(c)` renamed to `Color.set(c)` for clarity. `Renderable` module includes more common functionality.