### PR TITLE
Allow color to initialize from an existing color object

### DIFF
--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -66,6 +66,8 @@ module Ruby2D
           end
         when Array
           @r, @g, @b, @a = [c[0], c[1], c[2], c[3]]
+        when Color
+          @r, @g, @b, @a = [c.r, c.g, c.b, c.a]
         end
       end
     end
@@ -79,6 +81,7 @@ module Ruby2D
 
     # Check if the color is valid
     def self.is_valid?(c)
+      c.is_a?(Color)   ||  # color object
       @@colors.key?(c) ||  # keyword
       self.is_hex?(c)  ||  # hexadecimal value
 

--- a/test/color_spec.rb
+++ b/test/color_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Ruby2D::Color do
     it "raises error on bad color" do
       expect { Ruby2D::Color.new 42 }.to raise_error Ruby2D::Error
     end
+
+    it "accepts an existing color object" do
+      expect { Ruby2D::Color.new(Ruby2D::Color.new('red')) }.to_not raise_error Ruby2D::Error
+    end
+
+    it "assigns rgba from an existing color" do
+      c1 = Ruby2D::Color.new([20, 60, 80, 100])
+      c2 = Ruby2D::Color.new(c1)
+
+      expect([c2.r, c2.g, c2.b, c2.a]).to eq([20, 60, 80, 100])
+    end
   end
 
   describe "#opacity" do


### PR DESCRIPTION
Setting a 2d object's color to be random is great, however it's difficult to
re-use that color without manually extracting out the rgba values from that
color object. Ideally it would be convenient to be able to do this:

```ruby
square = Square.new(color: 'random')
square_two = Square.new(color: square.color)
```

This patch allows this behavior from any 2d shape, making it much easier to
reuse those random colors :)