### PR TITLE
Rescue console broken pipe

### DIFF
--- a/lib/ruby2d/cli/console.rb
+++ b/lib/ruby2d/cli/console.rb
@@ -31,19 +31,24 @@ loop do
     exit
   end
 
-  # Skip if command is an empty string
-  unless cmd.empty?
+  begin
+    # Skip if command is an empty string
+    unless cmd.empty?
 
-    # Send command to the Ruby file
-    stdin.puts cmd
+      # Send command to the Ruby file
+      stdin.puts cmd
 
-    # Read and print output from the Ruby file
-    puts stdout.gets
-    while stdout.ready? do
+      # Read and print output from the Ruby file
       puts stdout.gets
+      while stdout.ready? do
+        puts stdout.gets
+      end
     end
-  end
 
-  # Advance to next line
-  line += 1
+    # Advance to next line
+    line += 1
+  rescue Errno::EPIPE
+    puts "Can't connect to 2d application. See http://www.ruby2d.com/learn/console/#common-issues for more info"
+    exit 1
+  end
 end

--- a/lib/ruby2d/cli/console.rb
+++ b/lib/ruby2d/cli/console.rb
@@ -1,3 +1,6 @@
+# Interactive Ruby 2D console
+
+# Save the Ruby file from the command-line arguments
 rb_file = ARGV[1]
 
 # Check if source file provided is good
@@ -14,11 +17,12 @@ require 'open3'
 require 'readline'
 require 'io/wait'
 
-line = 1  # the current line number, to be incremented
+line = 1  # the current line number
 
-# Open a new process for the  Ruby file
+# Open a new process for the Ruby file
 stdin, stdout, stderr, wait_thr = Open3.popen3("ruby -r 'ruby2d/cli/enable_console' #{rb_file}")
 
+# Request input and send commands
 loop do
 
   # Read the next command
@@ -31,7 +35,9 @@ loop do
     exit
   end
 
+  # Try sending commands
   begin
+
     # Skip if command is an empty string
     unless cmd.empty?
 
@@ -43,12 +49,17 @@ loop do
       while stdout.ready? do
         puts stdout.gets
       end
+
     end
 
-    # Advance to next line
+    # Increment the line number
     line += 1
+
+  # Rescue exception if can't send commands to the Ruby 2D window
   rescue Errno::EPIPE
-    puts "Can't connect to 2d application. See http://www.ruby2d.com/learn/console/#common-issues for more info"
+    puts "Can't connect to the window (was it closed?)",
+         "For help, see: ruby2d.com/learn/console"
     exit 1
   end
+
 end


### PR DESCRIPTION
If the 2d application isn't running then we'll get an error trying to
write to it when using the console, we rescue that and direct the user
to the documentation.

While testing this I noticed that the program you're running doesn't
output to stdout, so I imagine users will hit this issue fairly
frequently unless they can see the output of their programs. I had a
typo in my require and the only output I saw was this message as the
program had already exited due to the exception and It didn't show me
why.

PR for the added docs is here: https://github.com/ruby2d/ruby2d.com/pull/10

[Best viewed with whitespace change hidden](https://github.com/ruby2d/ruby2d/pull/143/files?w=1)