### PR TITLE
Native extension fails on Mac w/ case-sensitive filesystem

### DIFF
--- a/ext/ruby2d/extconf.rb
+++ b/ext/ruby2d/extconf.rb
@@ -137,7 +137,7 @@ else
     add_flags(:ld, "#{ldir}/libsimple2d.a")
     add_flags(:ld, "#{ldir}/libSDL2.a #{ldir}/libSDL2_image.a #{ldir}/libSDL2_mixer.a #{ldir}/libSDL2_ttf.a")
     add_flags(:ld, "#{ldir}/libjpeg.a #{ldir}/libpng16.a #{ldir}/libtiff.a #{ldir}/libwebp.a")
-    add_flags(:ld, "#{ldir}/libmpg123.a #{ldir}/libogg.a #{ldir}/libflac.a #{ldir}/libvorbis.a #{ldir}/libvorbisfile.a")
+    add_flags(:ld, "#{ldir}/libmpg123.a #{ldir}/libogg.a #{ldir}/libFLAC.a #{ldir}/libvorbis.a #{ldir}/libvorbisfile.a")
     add_flags(:ld, "#{ldir}/libfreetype.a")
     add_flags(:ld, "-Wl,-framework,Cocoa -Wl,-framework,ForceFeedback")
 


### PR DESCRIPTION
When I `gem install ruby2d` I get this:
```
compiling ruby2d.c
linking shared-object ruby2d/ruby2d.bundle
clang: error: no such file or directory: '/Users/damien/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/ruby2d-0.9.1/ext/ruby2d/../../assets/macos/lib/libflac.a'
make: *** [ruby2d.bundle] Error 1
```

I suspect this is because the included library file is named `libFLAC.a` but `extconf.rb` says `libflac.a` in lowercase. I'm on macOS 10.14.4, but formatted the FS case-sensitive, which would explain if it's currently working for most Mac users.

I'm not sure if it's possible to override that by passing arguments at build time, without patching `extconf.rb`. I also tried passing `libs` when installing, but it seems Simple 2D is not packaged in homebrew, so I didn't try further.