### PR TITLE
fix(msys2): detect RubyInstaller correctly

### DIFF
--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -20,7 +20,7 @@ unless RUBY_ENGINE == 'mruby'
   require 'ruby2d/sound'
   require 'ruby2d/music'
 
-  if RUBY_PLATFORM =~ /mingw/
+  if defined?(RubyInstaller)
     s2d_dll_path = Gem::Specification.find_by_name('ruby2d').gem_dir + '/assets/mingw/bin'
     RubyInstaller::Runtime.add_dll_directory(File.expand_path(s2d_dll_path))
   end


### PR DESCRIPTION
On pure msys2 mingw64 environment, The code like below will fail:

```ruby
require 'ruby2d'
show
```

```
$ruby test.rb
Traceback (most recent call last):
        2: from test.rb:1:in `<main>'
        1: from C:/msys64/mingw64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
C:/msys64/mingw64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- ruby2d (LoadError)
        4: from test.rb:1:in `<main>'
        3: from C:/msys64/mingw64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
        2: from C:/msys64/mingw64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
        1: from C:/msys64/mingw64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
C:/msys64/mingw64/lib/ruby/gems/2.6.0/gems/ruby2d-0.9.2/lib/ruby2d.rb:25:in `<top (required)>': uninitialized constant RubyInstaller (NameError)
```


Because `RUBY_PLATFORM =~ /mingw/` also match with pure msys2 mingw64 environment.

this bug was cause by d79643513b6f939968dc6670de9be27b5cfbde48 .

ref:
- https://github.com/ruby2d/ruby2d/pull/91
- https://teratail.com/questions/202950

---

note

Currently, `rake test:native audio` will fail due to another issue(usage of `File.foreach`). This PR doesn't resolve this issue( #167 ) .