### PR TITLE
Adds openbsd support

### DIFF
--- a/ext/ruby2d/extconf.rb
+++ b/ext/ruby2d/extconf.rb
@@ -16,8 +16,6 @@ when /bsd/
   $platform = :bsd
 when /mingw/
   $platform = :windows
-when /openbsd/
-  $platform = :openbsd
 else
   $platform = nil
 end

--- a/ext/ruby2d/extconf.rb
+++ b/ext/ruby2d/extconf.rb
@@ -16,6 +16,8 @@ when /bsd/
   $platform = :bsd
 when /mingw/
   $platform = :windows
+when /openbsd/
+  $platform = :openbsd
 else
   $platform = nil
 end

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -59,11 +59,12 @@ module Ruby2D
         end
       end
 
-      # Get the fonts directory for the current platform
-      def directory
+      # Get the fonts directories for the current platform
+      def directories
         macos_font_path   = '/Library/Fonts'
         linux_font_path   = '/usr/share/fonts'
         windows_font_path = 'C:/Windows/Fonts'
+        openbsd_font_path = '/usr/X11R6/lib/X11/fonts'
 
         # If MRI and/or non-Bash shell (like cmd.exe)
         if Object.const_defined? :RUBY_PLATFORM
@@ -74,16 +75,20 @@ module Ruby2D
             linux_font_path
           when /mingw/
             windows_font_path
+          when /openbsd/
+            openbsd_font_path
           end
         # If MRuby
         else
           uname = `uname`
-          if uname.include? 'Darwin' # macOS
+          if uname.include? 'Darwin'  # macOS
             macos_font_path
           elsif uname.include? 'Linux'
             linux_font_path
           elsif uname.include? 'MINGW'
             windows_font_path
+          elsif uname.include? 'OpenBSD'
+            openbsd_font_path
           end
         end
       end

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -61,35 +61,23 @@ module Ruby2D
 
       # Get the fonts directory for the current platform
       def directory
-        macos_font_path   = '/Library/Fonts'
-        linux_font_path   = '/usr/share/fonts'
-        windows_font_path = 'C:/Windows/Fonts'
-        openbsd_font_path = '/usr/X11R6/lib/X11/fonts'
-
-        # If MRI and/or non-Bash shell (like cmd.exe)
-        if Object.const_defined? :RUBY_PLATFORM
-          case RUBY_PLATFORM
-          when /darwin/  # macOS
-            macos_font_path
-          when /linux/
-            linux_font_path
-          when /mingw/
-            windows_font_path
-          when /openbsd/
-            openbsd_font_path
-          end
-        # If MRuby
+        system_string = if Object.const_defined? :RUBY_PLATFORM
+          # If MRI and/or non-Bash shell (like cmd.exe)
+          RUBY_PLATFORM
         else
-          uname = `uname`
-          if uname.include? 'Darwin'  # macOS
-            macos_font_path
-          elsif uname.include? 'Linux'
-            linux_font_path
-          elsif uname.include? 'MINGW'
-            windows_font_path
-          elsif uname.include? 'OpenBSD'
-            openbsd_font_path
-          end
+          # MRuby
+          `uname`
+        end
+
+        case system_string
+        when /darwin/i  # macOS
+          '/Library/Fonts'
+        when /linux/i
+          '/usr/share/fonts'
+        when /mingw/i
+          'C:/Windows/Fonts'
+        when /openbsd/i
+          '/usr/X11R6/lib/X11/fonts'
         end
       end
 

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -61,23 +61,35 @@ module Ruby2D
 
       # Get the fonts directory for the current platform
       def directory
-        system_string = if Object.const_defined? :RUBY_PLATFORM
-          # If MRI and/or non-Bash shell (like cmd.exe)
-          RUBY_PLATFORM
-        else
-          # MRuby
-          `uname`
-        end
+        macos_font_path   = '/Library/Fonts'
+        linux_font_path   = '/usr/share/fonts'
+        windows_font_path = 'C:/Windows/Fonts'
+        openbsd_font_path = '/usr/X11R6/lib/X11/fonts'
 
-        case system_string
-        when /darwin/i  # macOS
-          '/Library/Fonts'
-        when /linux/i
-          '/usr/share/fonts'
-        when /mingw/i
-          'C:/Windows/Fonts'
-        when /openbsd/i
-          '/usr/X11R6/lib/X11/fonts'
+        # If MRI and/or non-Bash shell (like cmd.exe)
+        if Object.const_defined? :RUBY_PLATFORM
+          case RUBY_PLATFORM
+          when /darwin/  # macOS
+            macos_font_path
+          when /linux/
+            linux_font_path
+          when /mingw/
+            windows_font_path
+          when /openbsd/
+            openbsd_font_path
+          end
+        # If MRuby
+        else
+          uname = `uname`
+          if uname.include? 'Darwin'  # macOS
+            macos_font_path
+          elsif uname.include? 'Linux'
+            linux_font_path
+          elsif uname.include? 'MINGW'
+            windows_font_path
+          elsif uname.include? 'OpenBSD'
+            openbsd_font_path
+          end
         end
       end
 

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -59,8 +59,8 @@ module Ruby2D
         end
       end
 
-      # Get the fonts directories for the current platform
-      def directories
+      # Get the fonts directory for the current platform
+      def directory
         macos_font_path   = '/Library/Fonts'
         linux_font_path   = '/usr/share/fonts'
         windows_font_path = 'C:/Windows/Fonts'


### PR DESCRIPTION
Note: OpenBSD really has two standard font locations:

* base system fonts: `/usr/X11R6/lib/X11/fonts`
* user installed fonts: `/usr/local/share/fonts`

I opted for the system fonts path since it's guaranteed to exist.

Currently OpenBSD doesn't have a Simple2D port, but I've got one working locally that will be submitted soon.