### PR TITLE
Performance: Execute uname once

### DIFF
--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -63,11 +63,12 @@ module Ruby2D
           end
         # If MRuby
         else
-          if `uname`.include? 'Darwin'  # macOS
+          uname = `uname`
+          if uname.include? 'Darwin' # macOS
             macos_font_path
-          elsif `uname`.include? 'Linux'
+          elsif uname.include? 'Linux'
             linux_font_path
-          elsif `uname`.include? 'MINGW'
+          elsif uname.include? 'MINGW'
             windows_font_path
           end
         end


### PR DESCRIPTION
Instead of shelling out to `uname` up to three times, let's do it once and assign the result to a variable.