### PR TITLE
Fix bug in sprite direct draw

### DIFF
--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -261,7 +261,7 @@ module Ruby2D
 
       self.class.ext_draw([
         self, opts[:x], opts[:y], opts[:width], opts[:height], opts[:rotate],
-        opts[:clip_x], opts[:clip_y], opts[:clip_width], opts[:height],
+        opts[:clip_x], opts[:clip_y], opts[:clip_width], opts[:clip_height],
         opts[:color][0], opts[:color][1], opts[:color][2], opts[:color][3]
       ])
     end


### PR DESCRIPTION
Height was being sent rather than the height of a single animation frame in the clip.


Now this example program
```ruby
require 'ruby2d'

@size = 84

@sprite = Sprite.new('test/media/coin.png',
                     clip_width: @size,
                     clip_height: @size,
                     width: (@size * 1.5),
                     height: (@size * 1.5),
                     color: [0,1,0,1]) #GREEN
update do
end
render do
  @sprite.draw(x: 100,
               y: 100,
               color: [1,0,0,1]) #RED
end

show
```

Has output which looks correct:

![coin direct draw](https://user-images.githubusercontent.com/112153/126474637-3c7d3831-e5a1-4ed9-9718-62218705ff9a.png)
