### PR TITLE
Fix compiler warnings for string literals

### DIFF
--- a/ext/ruby2d/gl.c
+++ b/ext/ruby2d/gl.c
@@ -20,7 +20,7 @@ static GLfloat orthoMatrix[16] =
 /*
  * Prints current GL error
  */
-void R2D_GL_PrintError(char *error) {
+void R2D_GL_PrintError(const char *error) {
   R2D_Log(R2D_ERROR, "%s (%d)", error, glGetError());
 }
 
@@ -69,7 +69,7 @@ void R2D_GL_StoreContextInfo(R2D_Window *window) {
  * Creates a shader object, loads shader string, and compiles.
  * Returns 0 if shader could not be compiled.
  */
-GLuint R2D_GL_LoadShader(GLenum type, const GLchar *shaderSrc, char *shaderName) {
+GLuint R2D_GL_LoadShader(GLenum type, const GLchar *shaderSrc, const char *shaderName) {
 
   // Create the shader object
   GLuint shader = glCreateShader(type);
@@ -111,7 +111,7 @@ GLuint R2D_GL_LoadShader(GLenum type, const GLchar *shaderSrc, char *shaderName)
 /*
  * Check if shader program was linked
  */
-int R2D_GL_CheckLinked(GLuint program, char *name) {
+int R2D_GL_CheckLinked(GLuint program, const char *name) {
 
   GLint linked;
   glGetProgramiv(program, GL_LINK_STATUS, &linked);

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -702,11 +702,11 @@ int R2D_FreeWindow(R2D_Window *window);
 // Ruby 2D OpenGL Functions ////////////////////////////////////////////////////
 
 int R2D_GL_Init(R2D_Window *window);
-void R2D_GL_PrintError(char *error);
+void R2D_GL_PrintError(const char *error);
 void R2D_GL_PrintContextInfo(R2D_Window *window);
 void R2D_GL_StoreContextInfo(R2D_Window *window);
-GLuint R2D_GL_LoadShader(GLenum type, const GLchar *shaderSrc, char *shaderName);
-int R2D_GL_CheckLinked(GLuint program, char *name);
+GLuint R2D_GL_LoadShader(GLenum type, const GLchar *shaderSrc, const char *shaderName);
+int R2D_GL_CheckLinked(GLuint program, const char *name);
 void R2D_GL_GetViewportScale(R2D_Window *window, int *w, int *h, double *scale);
 void R2D_GL_SetViewport(R2D_Window *window);
 void R2D_GL_CreateTexture(


### PR DESCRIPTION
Literals are treated as read-only and so when we pass them to a function
they should be set to const as they cannot be modified. This clears up
all of my compiler warnings, previously I had 7.