### PR TITLE
Remove r/g/b/a attributes from Renderable classes

### DIFF
--- a/lib/ruby2d/circle.rb
+++ b/lib/ruby2d/circle.rb
@@ -13,7 +13,7 @@ module Ruby2D
       @radius = opts[:radius] || 50
       @sectors = opts[:sectors] || 30
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -19,7 +19,7 @@ module Ruby2D
       @height = opts[:height] || nil
       @rotate = opts[:rotate] || 0
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       unless ext_init(@path)
         raise Error, "Image `#{@path}` cannot be created"
       end

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -14,7 +14,7 @@ module Ruby2D
       @z = opts[:z] || 0
       @width = opts[:width] || 2
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -25,7 +25,7 @@ module Ruby2D
       @y4 = opts[:y4] || 100
       @z  = opts[:z]  || 0
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 

--- a/lib/ruby2d/rectangle.rb
+++ b/lib/ruby2d/rectangle.rb
@@ -10,7 +10,7 @@ module Ruby2D
       @width = opts[:width] || 200
       @height = opts[:height] || 100
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       update_coords(@x, @y, @width, @height)
       add
     end

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -31,18 +31,6 @@ module Ruby2D
     alias_method :colour, :color
     alias_method :colour=, :color=
 
-    # Allow shortcuts for setting color values
-    def r; self.color.r end
-    def g; self.color.g end
-    def b; self.color.b end
-    def a; self.color.a end
-    def r=(c); self.color.r = c end
-    def g=(c); self.color.g = c end
-    def b=(c); self.color.b = c end
-    def a=(c); self.color.a = c end
-    def opacity; self.color.opacity end
-    def opacity=(val); self.color.opacity = val end
-
     # Add a contains method stub
     def contains?(x, y)
       x >= @x && x <= (@x + @width) && y >= @y && y <= (@y + @height)

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -23,7 +23,7 @@ module Ruby2D
       @height = opts[:height] || nil
       @rotate = opts[:rotate] || 0
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
 
       # Flipping status, coordinates, and size, used internally
       @flip = nil

--- a/lib/ruby2d/square.rb
+++ b/lib/ruby2d/square.rb
@@ -11,7 +11,7 @@ module Ruby2D
       @z = opts[:z] || 0
       @width = @height = @size = opts[:size] || 100
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       update_coords(@x, @y, @size, @size)
       add
     end

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -15,7 +15,7 @@ module Ruby2D
       @size = opts[:size] || 20
       @rotate = opts[:rotate] || 0
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       @font_path = opts[:font] || Font.default
       create_font
       create_texture

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -17,7 +17,7 @@ module Ruby2D
       @y3 = opts[:y3] || 100
       @z  = opts[:z]  || 0
       self.color = opts[:color] || 'white'
-      self.opacity = opts[:opacity] if opts[:opacity]
+      self.color.opacity = opts[:opacity] if opts[:opacity]
       add
     end
 

--- a/test/circle_spec.rb
+++ b/test/circle_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Ruby2D::Circle do
       expect(circle.radius).to eq(40)
       expect(circle.sectors).to eq(50)
       expect(circle.color.r).to eq(2/3.0)
-      expect(circle.opacity).to eq(0.5)
+      expect(circle.color.opacity).to eq(0.5)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Ruby2D::Circle do
       circle.radius = 40
       circle.sectors = 50
       circle.color = 'gray'
-      circle.opacity = 0.5
+      circle.color.opacity = 0.5
 
       expect(circle.x).to eq(10)
       expect(circle.y).to eq(20)
@@ -46,7 +46,7 @@ RSpec.describe Ruby2D::Circle do
       expect(circle.radius).to eq(40)
       expect(circle.sectors).to eq(50)
       expect(circle.color.r).to eq(2/3.0)
-      expect(circle.opacity).to eq(0.5)
+      expect(circle.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/color_spec.rb
+++ b/test/color_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe Ruby2D::Color do
   describe "#opacity" do
     it "sets and returns the opacity" do
       s1 = Square.new
-      s1.opacity = 0.5
+      s1.color.opacity = 0.5
       s2 = Square.new(color: ['red', 'green', 'blue', 'yellow'])
-      s2.opacity = 0.7
-      expect(s1.opacity).to eq(0.5)
-      expect(s2.opacity).to eq(0.7)
+      s2.color.opacity = 0.7
+      expect(s1.color.opacity).to eq(0.5)
+      expect(s2.color.opacity).to eq(0.7)
     end
   end
 

--- a/test/image_spec.rb
+++ b/test/image_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Ruby2D::Image do
       expect(img.height).to eq(50)
       expect(img.rotate).to eq(60)
       expect(img.color.r).to eq(2/3.0)
-      expect(img.opacity).to eq(0.5)
+      expect(img.color.opacity).to eq(0.5)
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe Ruby2D::Image do
       img.height = 50
       img.rotate = 60
       img.color = 'gray'
-      img.opacity = 0.5
+      img.color.opacity = 0.5
 
       expect(img.x).to eq(10)
       expect(img.y).to eq(20)
@@ -61,7 +61,7 @@ RSpec.describe Ruby2D::Image do
       expect(img.height).to eq(50)
       expect(img.rotate).to eq(60)
       expect(img.color.r).to eq(2/3.0)
-      expect(img.opacity).to eq(0.5)
+      expect(img.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/line_spec.rb
+++ b/test/line_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Ruby2D::Line do
       expect(line.width).to eq(60)
       expect(line.length).to be_within(0.0001).of(28.2843)
       expect(line.color.r).to eq(2/3.0)
-      expect(line.opacity).to eq(0.5)
+      expect(line.color.opacity).to eq(0.5)
     end
 
     it "creates a new line with one color via string" do
@@ -79,7 +79,7 @@ RSpec.describe Ruby2D::Line do
       line.z = 50
       line.width = 60
       line.color = 'gray'
-      line.opacity = 0.5
+      line.color.opacity = 0.5
 
       expect(line.x1).to eq(10)
       expect(line.y1).to eq(20)
@@ -89,7 +89,7 @@ RSpec.describe Ruby2D::Line do
       expect(line.width).to eq(60)
       expect(line.length).to be_within(0.0001).of(28.2843)
       expect(line.color.r).to eq(2/3.0)
-      expect(line.opacity).to eq(0.5)
+      expect(line.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/quad_spec.rb
+++ b/test/quad_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Ruby2D::Quad do
       expect(quad.y4).to eq(80)
       expect(quad.z).to eq(90)
       expect(quad.color.r).to eq(2/3.0)
-      expect(quad.opacity).to eq(0.5)
+      expect(quad.color.opacity).to eq(0.5)
     end
 
     it "creates a new quad with one color via string" do
@@ -88,7 +88,7 @@ RSpec.describe Ruby2D::Quad do
       quad.y4 = 80
       quad.z = 90
       quad.color = 'gray'
-      quad.opacity = 0.5
+      quad.color.opacity = 0.5
 
       expect(quad.x1).to eq(10)
       expect(quad.y1).to eq(20)
@@ -100,7 +100,7 @@ RSpec.describe Ruby2D::Quad do
       expect(quad.y4).to eq(80)
       expect(quad.z).to eq(90)
       expect(quad.color.r).to eq(2/3.0)
-      expect(quad.opacity).to eq(0.5)
+      expect(quad.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/rectangle_spec.rb
+++ b/test/rectangle_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Ruby2D::Rectangle do
       expect(rectangle.width).to eq(40)
       expect(rectangle.height).to eq(50)
       expect(rectangle.color.r).to eq(2/3.0)
-      expect(rectangle.opacity).to eq(0.5)
+      expect(rectangle.color.opacity).to eq(0.5)
     end
 
     it "creates a new rectangle with one color via string" do
@@ -77,7 +77,7 @@ RSpec.describe Ruby2D::Rectangle do
       rectangle.width = 40
       rectangle.height = 50
       rectangle.color = 'gray'
-      rectangle.opacity = 0.5
+      rectangle.color.opacity = 0.5
 
       expect(rectangle.x).to eq(10)
       expect(rectangle.y).to eq(20)
@@ -85,7 +85,7 @@ RSpec.describe Ruby2D::Rectangle do
       expect(rectangle.width).to eq(40)
       expect(rectangle.height).to eq(50)
       expect(rectangle.color.r).to eq(2/3.0)
-      expect(rectangle.opacity).to eq(0.5)
+      expect(rectangle.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/renderable_spec.rb
+++ b/test/renderable_spec.rb
@@ -30,15 +30,6 @@ RSpec.describe Ruby2D::Renderable do
     expect(shape.color.g).to eq(0.2)
     expect(shape.color.b).to eq(0.3)
     expect(shape.color.a).to eq(0.4)
-
-    shape.r = 0.5
-    shape.g = 0.6
-    shape.b = 0.7
-    shape.a = 0.8
-    expect(shape.r).to eq(0.5)
-    expect(shape.g).to eq(0.6)
-    expect(shape.b).to eq(0.7)
-    expect(shape.a).to eq(0.8)
   end
 
   it "allows British English spelling of color (colour)" do
@@ -65,10 +56,6 @@ RSpec.describe Ruby2D::Renderable do
     expect(shape.color.g).to eq(0.8)
     expect(shape.color.b).to eq(0.7)
     expect(shape.color.a).to eq(0.6)
-    expect(shape.r).to eq(0.9)
-    expect(shape.g).to eq(0.8)
-    expect(shape.b).to eq(0.7)
-    expect(shape.a).to eq(0.6)
   end
 
   describe "#contains?" do

--- a/test/sprite_spec.rb
+++ b/test/sprite_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Ruby2D::Sprite do
       expect(spr.height).to eq(50)
       expect(spr.rotate).to eq(60)
       expect(spr.color.r).to eq(2/3.0)
-      expect(spr.opacity).to eq(0.5)
+      expect(spr.color.opacity).to eq(0.5)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Ruby2D::Sprite do
       spr.height = 50
       spr.rotate = 60
       spr.color = 'gray'
-      spr.opacity = 0.5
+      spr.color.opacity = 0.5
 
       expect(spr.x).to eq(10)
       expect(spr.y).to eq(20)
@@ -55,7 +55,7 @@ RSpec.describe Ruby2D::Sprite do
       expect(spr.height).to eq(50)
       expect(spr.rotate).to eq(60)
       expect(spr.color.r).to eq(2/3.0)
-      expect(spr.opacity).to eq(0.5)
+      expect(spr.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/square_spec.rb
+++ b/test/square_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Ruby2D::Square do
       expect(square.width).to eq(40)
       expect(square.height).to eq(40)
       expect(square.color.r).to eq(2/3.0)
-      expect(square.opacity).to eq(0.5)
+      expect(square.color.opacity).to eq(0.5)
     end
 
     it "creates a new square with one color via string" do
@@ -77,14 +77,14 @@ RSpec.describe Ruby2D::Square do
       square.z = 30
       square.size = 40
       square.color = 'gray'
-      square.opacity = 0.5
+      square.color.opacity = 0.5
 
       expect(square.x).to eq(10)
       expect(square.y).to eq(20)
       expect(square.z).to eq(30)
       expect(square.size).to eq(40)
       expect(square.color.r).to eq(2/3.0)
-      expect(square.opacity).to eq(0.5)
+      expect(square.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Ruby2D::Text do
       expect(txt.size).to eq(40)
       expect(txt.rotate).to eq(50)
       expect(txt.color.r).to eq(2/3.0)
-      expect(txt.opacity).to eq(0.5)
+      expect(txt.color.opacity).to eq(0.5)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Ruby2D::Text do
       txt.size = 40
       txt.rotate = 50
       txt.color = 'gray'
-      txt.opacity = 0.5
+      txt.color.opacity = 0.5
 
       expect(txt.x).to eq(10)
       expect(txt.y).to eq(20)
@@ -57,7 +57,7 @@ RSpec.describe Ruby2D::Text do
       expect(txt.size).to eq(40)
       expect(txt.rotate).to eq(50)
       expect(txt.color.r).to eq(2/3.0)
-      expect(txt.opacity).to eq(0.5)
+      expect(txt.color.opacity).to eq(0.5)
     end
   end
 

--- a/test/triangle_spec.rb
+++ b/test/triangle_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Ruby2D::Triangle do
       expect(triangle.y3).to eq(60)
       expect(triangle.z).to eq(70)
       expect(triangle.color.r).to eq(2/3.0)
-      expect(triangle.opacity).to eq(0.5)
+      expect(triangle.color.opacity).to eq(0.5)
     end
 
     it "creates a new triangle with one color via string" do
@@ -79,7 +79,7 @@ RSpec.describe Ruby2D::Triangle do
       triangle.y3 = 60
       triangle.z = 70
       triangle.color = 'gray'
-      triangle.opacity = 0.5
+      triangle.color.opacity = 0.5
 
       expect(triangle.x1).to eq(10)
       expect(triangle.y1).to eq(20)
@@ -89,7 +89,7 @@ RSpec.describe Ruby2D::Triangle do
       expect(triangle.y3).to eq(60)
       expect(triangle.z).to eq(70)
       expect(triangle.color.r).to eq(2/3.0)
-      expect(triangle.opacity).to eq(0.5)
+      expect(triangle.color.opacity).to eq(0.5)
     end
   end
 


### PR DESCRIPTION
As talked about in #160, it doesn't make a lot of sense to have these forwarding to `foo.color`, when `foo.color.r/g/b/a` can be used directly. This (imo) breaks the single responsibility principle, and adds duplication that doesn't need to be there.

- Removed all of the forwarding attributes.
- Updated tests and made sure that they all pass.