### PR TITLE
Image rendering refactor

### DIFF
--- a/ext/ruby2d/gl.c
+++ b/ext/ruby2d/gl.c
@@ -361,22 +361,6 @@ void R2D_GL_DrawTriangle(GLfloat x1, GLfloat y1,
 
 
 /*
- * Draw an image
- */
-void R2D_GL_DrawImage(R2D_Image *img) {
-  #if GLES
-    R2D_GLES_DrawImage(img);
-  #else
-    if (R2D_GL2) {
-      R2D_GL2_DrawImage(img);
-    } else {
-      R2D_GL3_DrawImage(img);
-    }
-  #endif
-}
-
-
-/*
  * Draw sprite
  */
 void R2D_GL_DrawSprite(R2D_Sprite *spr) {

--- a/ext/ruby2d/gl2.c
+++ b/ext/ruby2d/gl2.c
@@ -122,20 +122,6 @@ void R2D_GL2_NewDrawTexture(GLfloat coordinates[], GLfloat texture_coordinates[]
 
 
 /*
- * Draw image
- */
-void R2D_GL2_DrawImage(R2D_Image *img) {
-  R2D_GL2_DrawTexture(
-    img->x, img->y, img->width, img->height,
-    img->rotate, img->rx, img->ry,
-    img->color.r, img->color.g, img->color.b, img->color.a,
-    0.f, 0.f, 1.f, 0.f, 1.f, 1.f, 0.f, 1.f,
-    img->texture_id
-  );
-}
-
-
-/*
  * Draw sprite
  */
 void R2D_GL2_DrawSprite(R2D_Sprite *spr) {

--- a/ext/ruby2d/gl3.c
+++ b/ext/ruby2d/gl3.c
@@ -335,20 +335,6 @@ void R2D_GL3_NewDrawTexture(GLfloat coordinates[], GLfloat texture_coordinates[]
 
 
 /*
- * Draw image
- */
-void R2D_GL3_DrawImage(R2D_Image *img) {
-  R2D_GL3_DrawTexture(
-    img->x, img->y, img->width, img->height,
-    img->rotate, img->rx, img->ry,
-    img->color.r, img->color.g, img->color.b, img->color.a,
-    0.f, 0.f, 1.f, 0.f, 1.f, 1.f, 0.f, 1.f,
-    img->texture_id
-  );
-}
-
-
-/*
  * Draw sprite
  */
 void R2D_GL3_DrawSprite(R2D_Sprite *spr) {

--- a/ext/ruby2d/gles.c
+++ b/ext/ruby2d/gles.c
@@ -307,19 +307,6 @@ void R2D_GLES_NewDrawTexture(GLfloat coordinates[], GLfloat texture_coordinates[
   glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, indices);
 }
 
-/*
- * Draw image
- */
-void R2D_GLES_DrawImage(R2D_Image *img) {
-  R2D_GLES_DrawTexture(
-    img->x, img->y, img->width, img->height,
-    img->rotate, img->rx, img->ry,
-    img->color.r, img->color.g, img->color.b, img->color.a,
-    0.f, 0.f, 1.f, 0.f, 1.f, 1.f, 0.f, 1.f,
-    img->texture_id
-  );
-}
-
 
 /*
  * Draw sprite

--- a/ext/ruby2d/image.c
+++ b/ext/ruby2d/image.c
@@ -97,38 +97,6 @@ R2D_Image *R2D_CreateImage(const char *path) {
 
 
 /*
- * Rotate an image
- */
-void R2D_RotateImage(R2D_Image *img, GLfloat angle, int position) {
-
-  R2D_GL_Point p = R2D_GetRectRotationPoint(
-    img->x, img->y, img->width, img->height, position
-  );
-
-  img->rotate = angle;
-  img->rx = p.x;
-  img->ry = p.y;
-}
-
-
-/*
- * Draw an image
- */
-void R2D_DrawImage(R2D_Image *img) {
-  if (!img) return;
-
-  if (img->texture_id == 0) {
-    R2D_GL_CreateTexture(&img->texture_id, img->format,
-                         img->orig_width, img->orig_height,
-                         img->surface->pixels, GL_NEAREST);
-    SDL_FreeSurface(img->surface);
-  }
-
-  R2D_GL_DrawImage(img);
-}
-
-
-/*
  * Free an image
  */
 void R2D_FreeImage(R2D_Image *img) {

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -400,67 +400,6 @@ static R_VAL ruby2d_image_ext_load_image(R_VAL self, R_VAL rubyPath) {
 
 
 /*
- * Ruby2D::Image#ext_init
- * Initialize image structure data
- */
-#if MRUBY
-static R_VAL ruby2d_image_ext_init(mrb_state* mrb, R_VAL self) {
-  mrb_value path;
-  mrb_get_args(mrb, "o", &path);
-#else
-static R_VAL ruby2d_image_ext_init(R_VAL self, R_VAL path) {
-#endif
-  R2D_Image *img = R2D_CreateImage(RSTRING_PTR(path));
-  if (!img) return R_FALSE;
-
-  // Get width and height from Ruby class. If set, use it, else choose the
-  // native dimensions of the image.
-  R_VAL w = r_iv_get(self, "@width");
-  R_VAL h = r_iv_get(self, "@height");
-  r_iv_set(self, "@width" , r_test(w) ? w : INT2NUM(img->width));
-  r_iv_set(self, "@height", r_test(h) ? h : INT2NUM(img->height));
-  r_iv_set(self, "@data", r_data_wrap_struct(image, img));
-
-  return R_TRUE;
-}
-
-
-/*
- * Ruby2D::Image#self.ext_draw
- */
-#if MRUBY
-static R_VAL ruby2d_image_ext_draw(mrb_state* mrb, R_VAL self) {
-  mrb_value a;
-  mrb_get_args(mrb, "o", &a);
-#else
-static R_VAL ruby2d_image_ext_draw(R_VAL self, R_VAL a) {
-#endif
-  // `a` is the array representing the image
-
-  R2D_Image *img;
-  r_data_get_struct(r_ary_entry(a, 0), "@data", &image_data_type, R2D_Image, img);
-
-  img->x = NUM2DBL(r_ary_entry(a, 1));
-  img->y = NUM2DBL(r_ary_entry(a, 2));
-
-  R_VAL w = r_ary_entry(a, 3);
-  R_VAL h = r_ary_entry(a, 4);
-  if (r_test(w)) img->width  = NUM2INT(w);
-  if (r_test(h)) img->height = NUM2INT(h);
-
-  R2D_RotateImage(img, NUM2DBL(r_ary_entry(a, 5)), R2D_CENTER);
-
-  img->color.r = NUM2DBL(r_ary_entry(a, 6));
-  img->color.g = NUM2DBL(r_ary_entry(a, 7));
-  img->color.b = NUM2DBL(r_ary_entry(a, 8));
-  img->color.a = NUM2DBL(r_ary_entry(a, 9));
-
-  R2D_DrawImage(img);
-  return R_NIL;
-}
-
-
-/*
  * Free image structure attached to Ruby 2D `Image` class
  */
 #if MRUBY
@@ -1352,12 +1291,6 @@ void Init_ruby2d() {
 
   // Ruby2D::Image#ext_load_image
   r_define_method(ruby2d_image_class, "ext_load_image", ruby2d_image_ext_load_image, r_args_req(1));
-
-  // Ruby2D::Image#ext_init
-  r_define_method(ruby2d_image_class, "ext_init", ruby2d_image_ext_init, r_args_req(1));
-
-  // Ruby2D::Image#self.ext_draw
-  r_define_class_method(ruby2d_image_class, "ext_draw", ruby2d_image_ext_draw, r_args_req(1));
 
   // Ruby2D::Sprite
   R_CLASS ruby2d_sprite_class = r_define_class(ruby2d_module, "Sprite");

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -440,6 +440,16 @@ void R2D_DrawCircle(
  */
 R2D_Image *R2D_CreateImage(const char *path);
 
+/*
+ * Create a surface with image pixel data, given a file path
+ */
+SDL_Surface *R2D_CreateImageSurface(const char *path);
+
+/*
+ * Convert images to RGB format if they are in a different (BGR for example) format.
+ */
+void R2D_ImageConvertToRGB(SDL_Surface *surface);
+
 
 /*
  * Free an image

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -440,15 +440,6 @@ void R2D_DrawCircle(
  */
 R2D_Image *R2D_CreateImage(const char *path);
 
-/*
- * Rotate an image
- */
-void R2D_RotateImage(R2D_Image *img, GLfloat angle, int position);
-
-/*
- * Draw an image
- */
-void R2D_DrawImage(R2D_Image *img);
 
 /*
  * Free an image
@@ -691,7 +682,6 @@ void R2D_GL_DrawTriangle(
   GLfloat r2, GLfloat g2, GLfloat b2, GLfloat a2,
   GLfloat x3, GLfloat y3,
   GLfloat r3, GLfloat g3, GLfloat b3, GLfloat a3);
-void R2D_GL_DrawImage(R2D_Image *img);
 void R2D_GL_DrawSprite(R2D_Sprite *spr);
 void R2D_GL_DrawTile(R2D_Image *img, int x, int y, int tw, int th, GLfloat tx1, GLfloat ty1, GLfloat tx2,
   GLfloat ty2, GLfloat tx3, GLfloat ty3, GLfloat tx4, GLfloat ty4);
@@ -712,7 +702,6 @@ void R2D_GL_FlushBuffers();
     GLfloat r2, GLfloat g2, GLfloat b2, GLfloat a2,
     GLfloat x3, GLfloat y3,
     GLfloat r3, GLfloat g3, GLfloat b3, GLfloat a3);
-  void R2D_GLES_DrawImage(R2D_Image *img);
   void R2D_GLES_DrawSprite(R2D_Sprite *spr);
     void R2D_GLES_DrawTile(R2D_Image *img, int x, int y,
     int tw, int th,
@@ -738,8 +727,6 @@ void R2D_GL_FlushBuffers();
     GLfloat r2, GLfloat g2, GLfloat b2, GLfloat a2,
     GLfloat x3, GLfloat y3,
     GLfloat r3, GLfloat g3, GLfloat b3, GLfloat a3);
-  void R2D_GL2_DrawImage(R2D_Image *img);
-  void R2D_GL3_DrawImage(R2D_Image *img);
   void R2D_GL2_DrawSprite(R2D_Sprite *spr);
   void R2D_GL3_DrawSprite(R2D_Sprite *spr);
   void R2D_GL2_DrawTile(R2D_Image *img, int x, int y,

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -15,14 +15,18 @@ module Ruby2D
       @x = opts[:x] || 0
       @y = opts[:y] || 0
       @z = opts[:z] || 0
-      @width = opts[:width] || nil
-      @height = opts[:height] || nil
       @rotate = opts[:rotate] || 0
       self.color = opts[:color] || 'white'
       self.color.opacity = opts[:opacity] if opts[:opacity]
-      unless ext_init(@path)
-        raise Error, "Image `#{@path}` cannot be created"
-      end
+
+      @texture = Texture.new(*ext_load_image(@path))
+      @width = opts[:width] || @texture.width
+      @height = opts[:height] || @texture.height
+
+      # FIXME: Do we need to raise this somehow if ext_load_image fails ?
+      # unless ext_init(@path)
+      #   raise Error, "Image `#{@path}` cannot be created"
+      # end
       unless opts[:show] == false then add end
     end
 
@@ -34,20 +38,17 @@ module Ruby2D
         opts[:color] = [1.0, 1.0, 1.0, 1.0]
       end
 
-      self.class.ext_draw([
-        self, opts[:x], opts[:y], opts[:width], opts[:height], opts[:rotate],
-        opts[:color][0], opts[:color][1], opts[:color][2], opts[:color][3]
-      ])
+      render(x: opts[:x], y: opts[:y], width: opts[:width], height: opts[:height], color: Color.new(opts[:color]), rotate: opts[:rotate])
     end
 
     private
 
-    def render
-      self.class.ext_draw([
-        self, @x, @y, @width, @height, @rotate,
-        @color.r, @color.g, @color.b, @color.a
-      ])
-    end
+    def render(x: @x, y: @y, width: @width, height: @height, color: @color, rotate: @rotate)
+      vertices = Vertices.new(x, y, width, height, rotate)
 
+      @texture.draw(
+        vertices.coordinates, vertices.texture_coordinates, color
+      )
+    end
   end
 end

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -23,10 +23,6 @@ module Ruby2D
       @width = opts[:width] || @texture.width
       @height = opts[:height] || @texture.height
 
-      # FIXME: Do we need to raise this somehow if ext_load_image fails ?
-      # unless ext_init(@path)
-      #   raise Error, "Image `#{@path}` cannot be created"
-      # end
       unless opts[:show] == false then add end
     end
 

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -51,7 +51,7 @@ module Ruby2D
     private
 
     def render(x: @x, y: @y, color: @color, rotate: @rotate)
-      vertices = Vertices.new(x, y, @texture.width, @texture.height, rotate)
+      vertices = Vertices.new(x, y, @width, @height, rotate)
 
       @texture.draw(
         vertices.coordinates, vertices.texture_coordinates, color


### PR DESCRIPTION
This pull request changes the `Ruby2D::Image` class to render using the new texture functions. So a lot of the C code specifically for rendering Images can now be removed. We still have to keep the C `R2D_Image` struct as it is used by Sprite and Tileset. The `Ruby2D::Vertices` class can be re-used for Images as it supports rotation and scaling (by defining a width/height that is different from the original image).

Renders look the same as the `main` branch

<img width="812" alt="Screen Shot 2021-08-07 at 8 16 16 pm" src="https://user-images.githubusercontent.com/112153/128596861-e76af2e5-7dcb-40f1-a51f-9f1be86a3db5.png">

<img width="752" alt="Screen Shot 2021-08-07 at 8 15 31 pm" src="https://user-images.githubusercontent.com/112153/128596841-5b957b66-e931-4ed7-8748-7d040d9cca11.png">
