### PR TITLE
Remove Window instance variable warning

### DIFF
--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -109,9 +109,7 @@ module Ruby2D
       @render_proc = Proc.new {}
 
       # Detect if window is being used through the DSL or as a class instance
-      unless method(:update).parameters.empty? || method(:render).parameters.empty?
-        @using_dsl = true
-      end
+      @using_dsl = !(method(:update).parameters.empty? || method(:render).parameters.empty?)
 
       # Whether diagnostic messages should be printed
       @diagnostics = false


### PR DESCRIPTION
I get the following error when running a program using a window class:
> window.rb:589: warning: instance variable @using_dsl not initialized

Always setting `@using_dsl` even if it's false solves this problem.