### PR TITLE
Add font styling

### DIFF
--- a/ext/ruby2d/font.c
+++ b/ext/ruby2d/font.c
@@ -6,7 +6,7 @@
 /*
  * Create a TTF_Font object given a path to a font and a size
  */
-TTF_Font *R2D_FontCreateTTFFont(const char *path, int size) {
+TTF_Font *R2D_FontCreateTTFFont(const char *path, int size, const char *style) {
 
  // Check if font file exists
   if (!R2D_FileExists(path)) {
@@ -19,6 +19,16 @@ TTF_Font *R2D_FontCreateTTFFont(const char *path, int size) {
   if (!font) {
     R2D_Error("TTF_OpenFont", TTF_GetError());
     return NULL;
+  }
+
+  if(strncmp(style, "bold", 4) == 0) {
+    TTF_SetFontStyle(font, TTF_STYLE_BOLD);
+  } else if(strncmp(style, "italic", 6) == 0) {
+    TTF_SetFontStyle(font, TTF_STYLE_ITALIC);
+  } else if(strncmp(style, "underline", 9) == 0) {
+    TTF_SetFontStyle(font, TTF_STYLE_UNDERLINE);
+  } else if(strncmp(style, "strikethrough", 13) == 0) {
+    TTF_SetFontStyle(font, TTF_STYLE_STRIKETHROUGH);
   }
 
   return font;

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -652,10 +652,10 @@ static R_VAL ruby2d_music_ext_length(R_VAL self) {
 /*
  * Ruby2D::Font#ext_load
  */
-static R_VAL ruby2d_font_ext_load(R_VAL self, R_VAL path, R_VAL size) {
+static R_VAL ruby2d_font_ext_load(R_VAL self, R_VAL path, R_VAL size, R_VAL style) {
   R2D_Init();
 
-  TTF_Font *font = R2D_FontCreateTTFFont(RSTRING_PTR(path), NUM2INT(size));
+  TTF_Font *font = R2D_FontCreateTTFFont(RSTRING_PTR(path), NUM2INT(size), RSTRING_PTR(style));
   if (!font) {
     return R_NIL;
   }
@@ -1199,7 +1199,7 @@ void Init_ruby2d() {
   R_CLASS ruby2d_font_class = r_define_class(ruby2d_module, "Font");
 
   // Ruby2D::Font#ext_load
-  r_define_class_method(ruby2d_font_class, "ext_load", ruby2d_font_ext_load, r_args_req(2));
+  r_define_class_method(ruby2d_font_class, "ext_load", ruby2d_font_ext_load, r_args_req(3));
 
   // Ruby2D::Texture
   R_CLASS ruby2d_texture_class = r_define_class(ruby2d_module, "Texture");

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -408,7 +408,7 @@ void R2D_ImageConvertToRGB(SDL_Surface *surface);
 /*
  * Create a TTF_Font object given a path to a font and a size
  */
-TTF_Font *R2D_FontCreateTTFFont(const char *path, int size);
+TTF_Font *R2D_FontCreateTTFFont(const char *path, int size, const char *style);
 
 // Text ////////////////////////////////////////////////////////////////////////
 

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -6,17 +6,17 @@ module Ruby2D
 
     attr_reader :ttf_font
 
-    def initialize(path, size)
-      @ttf_font = Font.ext_load(path, size)
+    def initialize(path, size, style=nil)
+      @ttf_font = Font.ext_load(path, size, style.to_s)
     end
 
     class << self
-      def load(path, size)
+      def load(path, size, style=nil)
         unless File.exist? path
           raise Error, "Cannot find font file `#{path}`"
         end
 
-        @@loaded_fonts[[path, size]] ||= Font.new(path, size)
+        @@loaded_fonts[[path, size, style]] ||= Font.new(path, size, style)
       end
 
       # List all fonts, names only

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -14,6 +14,7 @@ module Ruby2D
       @text = text.to_s
       @size = opts[:size] || 20
       @rotate = opts[:rotate] || 0
+      @style = opts[:style]
       self.color = opts[:color] || 'white'
       self.color.opacity = opts[:opacity] if opts[:opacity]
       @font_path = opts[:font] || Font.default
@@ -59,7 +60,7 @@ module Ruby2D
     end
 
     def create_font
-      @font = Font.load(@font_path, @size)
+      @font = Font.load(@font_path, @size, @style)
     end
 
     def create_texture


### PR DESCRIPTION
When creating a text object you can now set the style attribute to be
either: 'bold', 'italic', 'underline' or 'strikethrough', any other
value results in regular font styling.