### PR TITLE
Add error handling around open windows

### DIFF
--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -33,6 +33,8 @@ module Ruby2D
     end
 
     def draw(opts = {})
+      Window.render_ready_check
+
       opts[:width] = opts[:width] || @width
       opts[:height] = opts[:height] || @height
       opts[:rotate] = opts[:rotate] || @rotate

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -187,6 +187,8 @@ module Ruby2D
     end
 
     def draw(opts = {})
+      Window.render_ready_check
+
       opts[:width] = opts[:width] || (@width || @clip_width)
       opts[:height] = opts[:height] || (@height || @clip_height)
       opts[:rotate] = opts[:rotate] || @rotate

--- a/lib/ruby2d/text.rb
+++ b/lib/ruby2d/text.rb
@@ -40,6 +40,8 @@ module Ruby2D
     end
 
     def draw(opts = {})
+      Window.render_ready_check
+
       opts[:rotate] = opts[:rotate] || @rotate
       unless opts[:color]
         opts[:color] = [1.0, 1.0, 1.0, 1.0]

--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -48,6 +48,8 @@ module Ruby2D
   end
 
   def draw
+    Window.render_ready_check
+
     render
   end
 

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -39,6 +39,8 @@ module Ruby2D
     end
 
     def self.draw(opts = {})
+      Window.render_ready_check
+
       ext_draw([
         opts[:x1], opts[:y1], opts[:color][0][0], opts[:color][0][1], opts[:color][0][2], opts[:color][0][3],
         opts[:x2], opts[:y2], opts[:color][1][0], opts[:color][1][1], opts[:color][1][2], opts[:color][1][3],
@@ -49,6 +51,8 @@ module Ruby2D
     private
 
     def render
+      Window.render_ready_check
+
       self.class.ext_draw([
         @x1, @y1, @c1.r, @c1.g, @c1.b, @c1.a,
         @x2, @y2, @c2.r, @c2.g, @c2.b, @c2.a,

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -4,6 +4,7 @@
 
 module Ruby2D
   class Window
+    @@open_window = false
 
     # Event structures
     EventDescriptor       = Struct.new(:type, :id)
@@ -187,6 +188,12 @@ module Ruby2D
 
       def close
         DSL.window.close
+      end
+
+      def render_ready_check
+        unless @@open_window
+          raise Error, "Attempting to draw before the window is ready. Please put calls to draw() inside of a render block."
+        end
       end
     end
 
@@ -614,7 +621,12 @@ module Ruby2D
 
     # Show the window
     def show
+      if @@open_window
+        raise Error, "Window#show called multiple times, Ruby2D only supports a single open window"
+      end
+
       ext_show
+      @@open_window = true
     end
 
     # Take screenshot
@@ -634,6 +646,7 @@ module Ruby2D
     # Close the window
     def close
       ext_close
+      @@open_window = false
     end
 
     # Private instance methods


### PR DESCRIPTION
Add two errors:
1) prevent users from calling 'show' multiple times as it currently
   doesn't function
2) prevent users directly drawing objects outside of the render block
   (this does not work as the window is not yet ready)