### PR TITLE
Add scaling to tileset and fix spacing bug

### DIFF
--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -19,6 +19,7 @@ module Ruby2D
       @spacing = opts[:spacing] || 0
       @tile_width = opts[:tile_width]
       @tile_height = opts[:tile_height]
+      @scale = opts[:scale] || 1
 
       unless opts[:show] == false then add end
     end
@@ -53,20 +54,28 @@ module Ruby2D
 
   private
 
+
   def render
+    scaled_padding = @padding * @scale
+    scaled_spacing = @spacing * @scale
+    scaled_tile_width = @tile_width * @scale
+    scaled_tile_height = @tile_height * @scale
+    scaled_width = @width * @scale
+    scaled_height = @height * @scale
+
     @tiles.each do |tile|
       crop = {
-        x: @padding + (tile.fetch(:tile_x) + @spacing) * @tile_width,
-        y: @padding + (tile.fetch(:tile_y) + @spacing) * @tile_height,
-        width: @tile_width,
-        height: @tile_height,
-        image_width: @width,
-        image_height: @height,
+        x: scaled_padding + (tile.fetch(:tile_x) * (scaled_spacing + scaled_tile_width)),
+        y: scaled_padding + (tile.fetch(:tile_y) * (scaled_spacing + scaled_tile_height)),
+        width: scaled_tile_width,
+        height: scaled_tile_height,
+        image_width: scaled_width,
+        image_height: scaled_height,
       }
 
       color = defined?(@color) ? @color : Color.new([1.0, 1.0, 1.0, 1.0])
 
-      vertices = Vertices.new(tile.fetch(:x), tile.fetch(:y), @tile_width, @tile_height, tile.fetch(:tile_rotate), crop: crop, flip: tile.fetch(:tile_flip))
+      vertices = Vertices.new(tile.fetch(:x), tile.fetch(:y), scaled_tile_width, scaled_tile_height, tile.fetch(:tile_rotate), crop: crop, flip: tile.fetch(:tile_flip))
 
       @texture.draw(
         vertices.coordinates, vertices.texture_coordinates, color

--- a/test/tileset.rb
+++ b/test/tileset.rb
@@ -3,13 +3,14 @@ require 'ruby2d'
 class GameWindow < Ruby2D::Window
   TILE_WIDTH = 36
   TILE_HEIGHT = 45
+  SCALE = 4
 
   def initialize
     super
-    set width: 108
-    set height: 135
+    set width: 108 * SCALE
+    set height: 135 * SCALE
     set background: 'white'
-    @tileset = Tileset.new('media/texture_atlas.png', tile_width: TILE_WIDTH, tile_height: TILE_HEIGHT)
+    @tileset = Tileset.new('media/texture_atlas.png', tile_width: TILE_WIDTH, tile_height: TILE_HEIGHT, scale: SCALE)
   end
 
   def update
@@ -20,21 +21,21 @@ class GameWindow < Ruby2D::Window
     @tileset.define_tile('num-3', 2, 0)
 
     @tileset.set_tile('num-1', [
-      {x: TILE_WIDTH * 0, y: TILE_HEIGHT * 0},
-      {x: TILE_WIDTH * 1, y: TILE_HEIGHT * 1},
-      {x: TILE_WIDTH * 2, y: TILE_HEIGHT * 2}
+      {x: TILE_WIDTH * SCALE * 0, y: TILE_HEIGHT * SCALE * 0},
+      {x: TILE_WIDTH * SCALE * 1, y: TILE_HEIGHT * SCALE * 1},
+      {x: TILE_WIDTH * SCALE * 2, y: TILE_HEIGHT * SCALE * 2}
     ])
 
     @tileset.set_tile('num-2', [
-      {x: TILE_WIDTH * 0, y: TILE_HEIGHT * 1},
-      {x: TILE_WIDTH * 1, y: TILE_HEIGHT * 2},
-      {x: TILE_WIDTH * 2, y: TILE_HEIGHT * 0},
+      {x: TILE_WIDTH * SCALE * 0, y: TILE_HEIGHT * SCALE * 1},
+      {x: TILE_WIDTH * SCALE * 1, y: TILE_HEIGHT * SCALE * 2},
+      {x: TILE_WIDTH * SCALE * 2, y: TILE_HEIGHT * SCALE * 0},
     ])
 
     @tileset.set_tile('num-3', [
-      {x: TILE_WIDTH * 0, y: TILE_HEIGHT * 2},
-      {x: TILE_WIDTH * 1, y: TILE_HEIGHT * 0},
-      {x: TILE_WIDTH * 2, y: TILE_HEIGHT * 1},
+      {x: TILE_WIDTH * SCALE * 0, y: TILE_HEIGHT * SCALE * 2},
+      {x: TILE_WIDTH * SCALE * 1, y: TILE_HEIGHT * SCALE * 0},
+      {x: TILE_WIDTH * SCALE * 2, y: TILE_HEIGHT * SCALE * 1},
     ])
   end
 


### PR DESCRIPTION
Previously: to scale the size of tiles displayed in a tileset, you would need
to multiply the tile width/height, the image width/height as well as the
spacing and padding values by the scale. This works but means that you need to
know the dimensions of the tileset image, rather than having it be detected and
you have to multiply each value which can be confusing.

This patch still allows you to manually set those values if you wish but
introduces a 'scale' attribute which will do the work for you, meaning now you
can set a scale without having to specify the width/height of the tileset image
manually and multiply all attributes.

This patch also fixes a bug where the spacing was not being calculated
correctly, it was using `(tile_x + spacing) * tile_width` which is incorrect,
it is now: `tile_x * (spacing + tile_width)`