### PR TITLE
docs: fix simple typo, deails -> details

### DIFF
--- a/ext/ruby2d/sound.c
+++ b/ext/ruby2d/sound.c
@@ -57,7 +57,7 @@ int R2D_GetSoundLength(R2D_Sound *snd) {
   int channels = 0;
 
   // Populate the frequency, format and channel variables
-  if (!Mix_QuerySpec(&frequency, &format, &channels)) return -1; // Querying audio deails failed
+  if (!Mix_QuerySpec(&frequency, &format, &channels)) return -1; // Querying audio details failed
   if (!snd) return -1;
 
   // points = bytes / samplesize


### PR DESCRIPTION
There is a small typo in ext/ruby2d/sound.c.

Should read `details` rather than `deails`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md