### PR TITLE
Add height and width aliases on Renderable

### DIFF
--- a/lib/ruby2d/circle.rb
+++ b/lib/ruby2d/circle.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Circle
-    include Renderable
+    prepend Renderable
 
     attr_accessor :x, :y, :radius, :sectors
 

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Image
-    include Renderable
+    prepend Renderable
 
     attr_reader :path
     attr_accessor :x, :y, :width, :height, :rotate, :data

--- a/lib/ruby2d/line.rb
+++ b/lib/ruby2d/line.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Line
-    include Renderable
+    prepend Renderable
 
     attr_accessor :x1, :x2, :y1, :y2, :width
 

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Quad
-    include Renderable
+    prepend Renderable
 
     # Coordinates in clockwise order, starting at top left:
     # x1,y1 == top left

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -4,6 +4,8 @@ module Ruby2D
   module Renderable
 
     attr_reader :x, :y, :z, :width, :height, :color
+    alias_method :w, :width
+    alias_method :h, :height
 
     # Set the z position (depth) of the object
     def z=(z)

--- a/lib/ruby2d/renderable.rb
+++ b/lib/ruby2d/renderable.rb
@@ -7,6 +7,12 @@ module Ruby2D
     alias_method :w, :width
     alias_method :h, :height
 
+    def initialize(*args)
+      @width = w unless w.nil?
+      @height = h unless h.nil?
+      super()
+    end
+
     # Set the z position (depth) of the object
     def z=(z)
       remove
@@ -37,6 +43,5 @@ module Ruby2D
     def contains?(x, y)
       x >= @x && x <= (@x + @width) && y >= @y && y <= (@y + @height)
     end
-
   end
 end

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Sprite
-    include Renderable
+    prepend Renderable
 
     attr_reader :path
     attr_accessor :rotate, :loop, :clip_x, :clip_y, :clip_width, :clip_height, :data, :x, :y, :width, :height

--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Tileset
-    include Renderable
+    prepend Renderable
 
     def initialize(path, opts = {})
       @path = path

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -2,7 +2,7 @@
 
 module Ruby2D
   class Triangle
-    include Renderable
+    prepend Renderable
 
     attr_accessor :x1, :y1, :c1,
                   :x2, :y2, :c2,

--- a/test/renderable_spec.rb
+++ b/test/renderable_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe Ruby2D::Renderable do
 
   # Create and use a fresh class to ensure nothing is overridden
   class SomeShape
-    include Renderable
-    def initialize(x: 0, y: 0, width: 100, height: 100)
-      @x, @y, @width, @height = x, y, width, height
-    end
+    prepend Renderable
+
+    def initialize(x: 0, y: 0, w: 100, h: 100); end
   end
 
   it "allows colors to be set on objects" do

--- a/test/square_spec.rb
+++ b/test/square_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Ruby2D::Square do
       expect(square.y).to eq(20)
       expect(square.z).to eq(30)
       expect(square.size).to eq(40)
-      expect(square.width).to eq(40)
-      expect(square.height).to eq(40)
+      expect(square.w).to eq(40)
+      expect(square.h).to eq(40)
       expect(square.color.r).to eq(2/3.0)
       expect(square.color.opacity).to eq(0.5)
     end


### PR DESCRIPTION
This PR is adds the [desired](https://github.com/ruby2d/ruby2d/projects/1#card-64994621) aliases `:h` and `:w` for `Renderable#height` and `Renderable#width`.

I also made a tiny change to `square_spec.rb` in an attempt for test coverage. That being said, there are some [pretty decent arguments for _*not*_ testing aliases](https://github.com/rspec/rspec-core/issues/1962). 🤷 Let me know if you want the test ganked. 

I hope this helps clear some tiny amount of room on your plate. Thank you for this beautiful addition to the Ruby ecosystem. 
