### PR TITLE
Limit the amount of fonts to be cached

### DIFF
--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -2,6 +2,8 @@
 
 module Ruby2D
   class Font
+    FONT_CACHE_LIMIT = 100
+
     @@loaded_fonts = {}
 
     attr_reader :ttf_font
@@ -16,7 +18,11 @@ module Ruby2D
           raise Error, "Cannot find font file `#{path}`"
         end
 
-        @@loaded_fonts[[path, size, style]] ||= Font.new(path, size, style)
+        (@@loaded_fonts[[path, size, style]] ||= Font.new(path, size, style)).tap do |font|
+          if @@loaded_fonts.size > FONT_CACHE_LIMIT
+            @@loaded_fonts.shift
+          end
+        end
       end
 
       # List all fonts, names only


### PR DESCRIPTION
Previously we would cache every font that the user created that had a unique
font face, size and any styles (such as bold or italic).

This meant that if you increased the font size by a tiny fraction every frame,
then it would create a new font object every frame, resulting in 1000s of fonts
that we cached and never let go. In these circumstances it's easier to not
attempt to cache all of the fonts, and so setting a limit of 100 fonts to cache
as the maximum means that we can limit the amount of memory the program will
consume, 100 font variations should be plenty for most programs and programs
that use more will pay a small performance penalty but they won't have
uncontrolled memory growth any more.