### PR TITLE
Update ruby2d.rb

### DIFF
--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -28,6 +28,17 @@ unless RUBY_ENGINE == 'mruby'
   if defined?(RubyInstaller)
     s2d_dll_path = Gem::Specification.find_by_name('ruby2d').gem_dir + '/assets/mingw/bin'
     RubyInstaller::Runtime.add_dll_directory(File.expand_path(s2d_dll_path))
+  elsif RUBY_PLATFORM =~ /mingw/
+    # https://stackoverflow.com/a/59045531/1143732
+    require 'fiddle/import'
+    require 'fiddle/types'
+    module WinAPI
+      extend Fiddle::Importer
+      dlload 'kernel32.dll'
+      include Fiddle::Win32Types
+      extern 'int SetDllDirectory(LPCSTR)'
+    end
+    WinAPI.SetDllDirectory(Gem::Specification.find_by_name('ruby2d').gem_dir + '/assets/mingw/bin')
   end
 
   require 'ruby2d/ruby2d'  # load native extension

--- a/lib/ruby2d/cli/build.rb
+++ b/lib/ruby2d/cli/build.rb
@@ -73,7 +73,7 @@ def build_native(rb_file)
   check_build_src_file(rb_file)
 
   # Check if MRuby exists; if not, quit
-  if `which mruby`.empty?
+  if `which mruby`.empty? || `where mruby`.empty?
     puts "#{'Error:'.error} Can't find MRuby, which is needed to build native Ruby 2D applications.\n"
     exit
   end

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -273,7 +273,7 @@ module Ruby2D
         raise Error, "Cannot remove '#{o.class}' from window!"
       end
 
-      collection = o.class.ancestors.include?(Ruby2D::Entity) ? @entities : @objects
+      collection = o.class.ancestors.include?('Ruby2D::Entity') ? @entities : @objects
       if i = collection.index(o)
         collection.delete_at(i)
         true


### PR DESCRIPTION
If you use a non-RubyInstaller version of Ruby (IE from the likes of MSYS2), the "RubyInstaller" class is not available.

This prevents Ruby2D from running your scripts, citing a missing `ruby2d.so` file.

The reason this was happening is because of the following line: `RubyInstaller::Runtime.add_dll_directory(File.expand_path(s2d_dll_path))`

The above line adds the `assets/mingw/bin` folder to an include list (so Ruby2D can use the DLL's it contains), but is dependent on `RubyInstaller`. The fix is to get rid of this dependency, which can be done using the `fiddle` gem. It seems that `fiddle` is a default Ruby gem, so everybody should have it installed.

The above code works for me. It's not been tested on other versions of Ruby.