### PR TITLE
Improve tileset rendering performance

### DIFF
--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -2,6 +2,8 @@
 
 module Ruby2D
   class Tileset
+    DEFAULT_COLOR = Color.new([1.0, 1.0, 1.0, 1.0])
+
     include Renderable
 
     def initialize(path, opts = {})
@@ -46,42 +48,41 @@ module Ruby2D
     def clear_tiles
       @tiles = []
     end
-  end
 
-  def draw
-    Window.render_ready_check
+    def draw
+      Window.render_ready_check
 
-    render
-  end
+      render
+    end
 
-  private
+    private
 
+    def render
+      scaled_padding = @padding * @scale
+      scaled_spacing = @spacing * @scale
+      scaled_tile_width = @tile_width * @scale
+      scaled_tile_height = @tile_height * @scale
+      scaled_width = @width * @scale
+      scaled_height = @height * @scale
 
-  def render
-    scaled_padding = @padding * @scale
-    scaled_spacing = @spacing * @scale
-    scaled_tile_width = @tile_width * @scale
-    scaled_tile_height = @tile_height * @scale
-    scaled_width = @width * @scale
-    scaled_height = @height * @scale
+      @tiles.each do |tile|
+        crop = {
+          x: scaled_padding + (tile.fetch(:tile_x) * (scaled_spacing + scaled_tile_width)),
+          y: scaled_padding + (tile.fetch(:tile_y) * (scaled_spacing + scaled_tile_height)),
+          width: scaled_tile_width,
+          height: scaled_tile_height,
+          image_width: scaled_width,
+          image_height: scaled_height,
+        }
 
-    @tiles.each do |tile|
-      crop = {
-        x: scaled_padding + (tile.fetch(:tile_x) * (scaled_spacing + scaled_tile_width)),
-        y: scaled_padding + (tile.fetch(:tile_y) * (scaled_spacing + scaled_tile_height)),
-        width: scaled_tile_width,
-        height: scaled_tile_height,
-        image_width: scaled_width,
-        image_height: scaled_height,
-      }
+        color = defined?(@color) ? @color : DEFAULT_COLOR
 
-      color = defined?(@color) ? @color : Color.new([1.0, 1.0, 1.0, 1.0])
+        vertices = Vertices.new(tile.fetch(:x), tile.fetch(:y), scaled_tile_width, scaled_tile_height, tile.fetch(:tile_rotate), crop: crop, flip: tile.fetch(:tile_flip))
 
-      vertices = Vertices.new(tile.fetch(:x), tile.fetch(:y), scaled_tile_width, scaled_tile_height, tile.fetch(:tile_rotate), crop: crop, flip: tile.fetch(:tile_flip))
-
-      @texture.draw(
-        vertices.coordinates, vertices.texture_coordinates, color
-      )
+        @texture.draw(
+          vertices.coordinates, vertices.texture_coordinates, color
+        )
+      end
     end
   end
 end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -30,10 +30,17 @@ module Ruby2D
     end
 
     def coordinates
-      x1, y1 = rotate(@x,          @y);           # Top left
-      x2, y2 = rotate(@x + @width, @y);           # Top right
-      x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
-      x4, y4 = rotate(@x,          @y + @height); # Bottom left
+      if @rotate == 0
+        x1, y1 = @x,          @y;           # Top left
+        x2, y2 = @x + @width, @y;           # Top right
+        x3, y3 = @x + @width, @y + @height; # Bottom right
+        x4, y4 = @x,          @y + @height; # Bottom left
+      else
+        x1, y1 = rotate(@x,          @y);           # Top left
+        x2, y2 = rotate(@x + @width, @y);           # Top right
+        x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
+        x4, y4 = rotate(@x,          @y + @height); # Bottom left
+      end
 
       [ x1, y1, x2, y2, x3, y3, x4, y4 ]
     end
@@ -57,8 +64,6 @@ module Ruby2D
     private
 
     def rotate(x, y)
-      return [x, y] if @rotate == 0
-
       # Convert from degrees to radians
       angle = @rotate * Math::PI / 180.0
 

--- a/test/render-perf-tiles.rb
+++ b/test/render-perf-tiles.rb
@@ -22,7 +22,7 @@ render do
 
   tileset.clear_tiles
 
-  # 10,000 squares drawn at ~28 fps
+  # 10,000 squares drawn at ~39 fps
   # Apple M1 8 core CPU / 8 core GPU
   125.times do |i|
     79.times do |j|


### PR DESCRIPTION
Improve the performance of the `render-perf-tiles` test by using a singleton
color object rather than creating a new color each time. On my machine this
took the FPS of that test from 26FPS to 39FPS. A 50% improvement


The `Tileset#render` indentation was broken, so that's why the diff is a bit big.

The two major changes are:
  - Do not create a new color object for each vertices render (this occurs for each tile in a tileset)
  - Use an if/else for figuring out if vertices needs to rotate or not, calling a method and creating a new array object can have a large effect when it's called 10 000s / 100 000s of times per second