### PR TITLE
Support nested Sprite proc/do calls for sequencing animations

### DIFF
--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -177,8 +177,13 @@ module Ruby2D
           unless @loop
             # Stop animation and play block, if provided
             stop
-            if @done_proc then @done_proc.call end
-            @done_proc = nil
+            if @done_proc
+              # allow proc to make nested `play/do` calls to sequence multiple
+              # animations by clearing `@done_proc` before the call
+              kept_done_proc = @done_proc
+              @done_proc = nil
+              kept_done_proc.call
+            end
           end
         end
 

--- a/test/sprite.rb
+++ b/test/sprite.rb
@@ -80,6 +80,18 @@ atlas = Sprite.new(
 
 atlas.play animation: :count, loop: true
 
+def climb_up_down_up_down_walk(hero)
+  # test nested play/do
+  hero.play animation: :climb do
+    hero.play animation: :climb, flip: :vertical do
+      hero.play animation: :climb do
+        hero.play animation: :climb, flip: :vertical do
+          hero.play animation: :walk, loop: true
+        end
+      end
+    end
+  end
+end
 
 on :key_down do |e|
   close if e.key == 'escape'
@@ -109,6 +121,8 @@ on :key_down do |e|
     hero.play animation: :climb, loop: true, flip: :vertical
   when 'h'
     hero.play animation: :climb, loop: true, flip: :both
+  when 'space'
+    climb_up_down_up_down_walk hero
   when 'c'
     hero.play animation: :cheer
   end


### PR DESCRIPTION
Fixes #232 

* Fix clears `@done_proc` _before_ making the proc call, which allows subsequent calls to `play` to set a done proc which doesn't get clobbered.
* Test has a nested play/do call when user hits the "space" bar to make hero climb up/down/up/down and then walk right. 
