### PR TITLE
Optional image caching.

### DIFF
--- a/lib/ruby2d/version.rb
+++ b/lib/ruby2d/version.rb
@@ -1,5 +1,5 @@
 # Ruby2D::VERSION
 
 module Ruby2D
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end


### PR DESCRIPTION
This optimizes memory usage for many identical images.

Without caching, creating 500 identical images on my machine takes ~ 700 mb:
```ruby
require 'ruby2d'

path = 'foobar.jpg'

500.times { Image.new(path) }

show
```

With caching, it all began to take ~ 200 mb:
```ruby
require 'ruby2d'

path = 'foobar.jpg'

500.times { Image.new(path, cache: true) }

show
```

The example, of course, is unrealistic, but caching is a useful thing. :)