### PR TITLE
Tweaked canvas impl and separated fill/draw_rect

### DIFF
--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -2,10 +2,53 @@
 
 #include "ruby2d.h"
 
+Uint32 R2D_Canvas_Color2RGBA(SDL_Surface *surf, double r, double g, double b, double a) {
+  return SDL_MapRGBA(surf->format, r * 255, g * 255, b * 255, a * 255);
+}
+
 /*
- * Draw a rectangle on a canvas
+ * Draw a filled rectangle on a canvas using a pre-converted RGBA colour value.
  */
-void R2D_Canvas_DrawRect(SDL_Surface *surf, int x, int y, int w, int h, double r, double g, double b, double a) {
+void R2D_Canvas_FillRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba) {
   SDL_Rect rect = { .x = x, .y = y, .w = w, .h = h };
-  SDL_FillRect(surf, &rect, SDL_MapRGBA(surf->format, r * 255, g * 255, b * 255, a * 255));
+  SDL_FillRect(surf, &rect, rgba);
+}
+
+/*
+ * Draw the outline of a rectangle on a canvas using a pre-converted RGBA colour value.
+ */
+void R2D_Canvas_DrawRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba) {
+  SDL_Rect rect = { .x = x, .y = y, .w = w, .h = 1 };
+  SDL_FillRect(surf, &rect, rgba);    // top side
+  rect.h = h; rect.w = 1;
+  SDL_FillRect(surf, &rect, rgba);    // left side
+  rect.x += w - 1;
+  SDL_FillRect(surf, &rect, rgba);    // right side
+  rect.x = x; rect.w = w; rect.h = 1; rect.y += h - 1;
+  SDL_FillRect(surf, &rect, rgba);    // bottom side
+}
+
+/*
+ * Draw a thick line on a canvas using a pre-converted RGBA colour value.
+ */
+void R2D_Canvas_DrawLine_RGBA(SDL_Surface *surf, int x1, int y1, int x2, int y2, int thickness, Uint32 rgba) {
+  double x = x2 - x1;
+  double y = y2 - y1;
+  double length = sqrt(x*x + y*y);
+  double addx = x / length;
+  double addy = y / length;
+  x = x1;
+  y = y1;
+
+  // Draw the pixel on the canvas
+  for (int i = 0; i < length; i += 1) {
+    R2D_Canvas_FillRect_RGBA(
+      surf, x, y,
+      thickness, thickness,  // w & h are same val, the pixel "size" based on thickness
+      rgba
+    );
+    x += addx;
+    y += addy;
+  }
+
 }

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -506,9 +506,24 @@ void R2D_FreeSound(R2D_Sound *snd);
 // Canvas //////////////////////////////////////////////////////////////////////
 
 /*
- * Draw a rectangle on a canvas
+ * Convert colour to a 32-bit RGBA integer
  */
-void R2D_Canvas_DrawRect(SDL_Surface *surf, int x, int y, int w, int h, double r, double g, double b, double a);
+Uint32 R2D_Canvas_Color2RGBA(SDL_Surface *surf, double r, double g, double b, double a);
+
+/*
+ * Draw a rectangle on a canvas using a pre-converted RGBA colour value.
+ */
+void R2D_Canvas_FillRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba);
+
+/*
+ * Draw the outline of a rectangle on a canvas using a pre-converted RGBA colour value.
+ */
+void R2D_Canvas_DrawRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba);
+
+/*
+ * Draw a thick line on a canvas using a pre-converted RGBA colour value.
+ */
+void R2D_Canvas_DrawLine_RGBA(SDL_Surface *surf, int x1, int y1, int x2, int y2, int thickness, Uint32 rgba);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -20,7 +20,18 @@ module Ruby2D
       @texture = Texture.new(@ext_pixel_data, @width, @height)
       unless opts[:show] == false then add end
     end
+    
+    # Draw a filled rectangle.
+    def fill_rectangle(opts = {})
+      clr = Color.new(opts[:color] || opts[:colour])
+      ext_fill_rectangle([
+        opts[:x], opts[:y], opts[:width], opts[:height],
+        clr.r, clr.g, clr.b, clr.a
+      ])
+      update_texture if @update
+    end
 
+    # Draw an outline of a rectangle
     def draw_rectangle(opts = {})
       clr = Color.new(opts[:color] || opts[:colour])
       ext_draw_rectangle([
@@ -30,6 +41,7 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Draw a straight line
     def draw_line(opts = {})
       clr = Color.new(opts[:color] || opts[:colour])
       ext_draw_line([

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -17,6 +17,12 @@ update do
     color: [rand, rand, rand, 1]
   )
 
+  canvas.fill_rectangle(
+    x: Window.mouse_x - 50 + 5, y: Window.mouse_y - 50 + 5,
+    width: 40, height: 40,
+    color: [rand, rand, rand, 1]
+  )
+
   canvas.draw_line(
     x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, width: 1,
     color: [rand, rand, rand, 1]


### PR DESCRIPTION
@blacktm, here're some tweaks to the Canvas implementation as follows:

- Separated internal colour -> rgba conversion
  - Re-defined the `R2D_Canvas_*` functions so they all take colour as RGBA `uint32`
  - Modified the `ruby2d_canvas_ext_*` callers to convert the `double` colour components before calling the R2D functions. 
  - This ensures colour is converted _once_ per drawing primitive.
- Defined separate `fill_rect` and `draw_rect` where I've taken the liberty of considering "draw" to mean outline only. 
  - I debated between passing a `style: "filled" | "outline"` parameter, but decided to keep it simple for now.
- Modified canvas test to draw a outline rect with a nested smaller filled rect.