### PR TITLE
Canvas refactor using sdl renderer

### DIFF
--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -2,36 +2,69 @@
 
 #include "ruby2d.h"
 
+typedef struct {
+  float x;
+  float y;
+} vector_t;
+
+static float vector_magnitude(const vector_t *vec) {
+  return sqrtf((vec->x * vec->x) + (vec->y * vec->y));
+}
+
+static vector_t *vector_normalize_self(vector_t *vec) {
+  float mag = vector_magnitude(vec);
+  if (mag == 0) mag = INFINITY;
+  vec->x /= mag;
+  vec->y /= mag;
+  return vec;
+}
+
+static vector_t *vector_perpendicular_self(vector_t *vec) {
+  float tmp_x = vec->x;
+  vec->x = vec->y;
+  vec->y = -tmp_x;
+  return vec;
+}
+
+static vector_t *vector_multiply_self(vector_t *vec, float value) {
+  vec->x *= value;
+  vec->y *= value;
+  return vec;
+}
+
 /*
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
+ * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawLine(SDL_Renderer *render, int x1, int y1, int x2, int y2, int thickness) {
-  if (thickness == 1) {
-    SDL_RenderDrawLine(render, x1, y1, x2, y2);
+void R2D_Canvas_DrawThickLine(SDL_Renderer *render, 
+                       int x1, int y1, int x2, int y2, int thickness, 
+                       int r, int g, int b, int a) {
+
+  if (thickness <= 1) {
     return;
   }
-  // TODO replace with a polygon filler for thick lines
-  // ------------
 
-  // thick line, draw using fill rectangles
-  float x = x2 - x1;
-  float y = y2 - y1;
-  float length = sqrt(x*x + y*y);
-  float addx = x / length;
-  float addy = y / length;
-  x = x1;
-  y = y1;
-  SDL_Rect pixel = { .x = x, .y = y, .w = thickness, .h = thickness };
+  vector_t vec = { .x = (x2 - x1), .y = (y2 - y1) };
+  
+  // calculate perpendicular with half-thickness in place
+  vector_multiply_self(vector_perpendicular_self(vector_normalize_self(&vec)), thickness / 2.0f);
+  
+  // calculate perp vertices based on thickness
+  SDL_Vertex verts[4];
 
-  // Draw think lines without blending for now
-  SDL_SetRenderDrawBlendMode(render, SDL_BLENDMODE_NONE);
-  // Draw the pixel on the canvas
-  for (int i = 0; i < length; i += 1) {
-    pixel.x = x;
-    pixel.y = y;
-    SDL_RenderFillRect(render, &pixel);
-    x += addx;
-    y += addy;
+  verts[0].position = (SDL_FPoint) { .x = x1 + vec.x, .y = y1 + vec.y };
+  verts[1].position = (SDL_FPoint) { .x = x2 + vec.x, .y = y2 + vec.y };
+  verts[2].position = (SDL_FPoint) { .x = x2 - vec.x, .y = y2 - vec.y };
+  verts[3].position = (SDL_FPoint) { .x = x1 - vec.x, .y = y1 - vec.y };
+
+  // set the vertex colour
+  for (register int i=0; i< 4; i++) {
+    verts[i].color = (SDL_Color) {
+      .r = r, .g = g, .b = b, .a = a
+    };
   }
-  SDL_SetRenderDrawBlendMode(render, SDL_BLENDMODE_BLEND);
+
+  // sub-divide the two triangles; we know this is convex
+  int indices[] = { 0, 1, 2, 2, 3, 0 };
+  SDL_RenderGeometry(render, NULL, verts, 4, indices, 6);
 }

--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -2,33 +2,63 @@
 
 #include "ruby2d.h"
 
-typedef struct {
-  float x;
-  float y;
-} vector_t;
+typedef SDL_FPoint vector_t;
 
-static float vector_magnitude(const vector_t *vec) {
+static float vector_magnitude(const vector_t *vec)
+{
   return sqrtf((vec->x * vec->x) + (vec->y * vec->y));
 }
 
-static vector_t *vector_normalize_self(vector_t *vec) {
+static vector_t *vector_normalize(vector_t *vec)
+{
   float mag = vector_magnitude(vec);
-  if (mag == 0) mag = INFINITY;
+  if (mag == 0)
+    mag = INFINITY;
   vec->x /= mag;
   vec->y /= mag;
   return vec;
 }
 
-static vector_t *vector_perpendicular_self(vector_t *vec) {
+static vector_t *vector_perpendicular(vector_t *vec)
+{
   float tmp_x = vec->x;
   vec->x = vec->y;
   vec->y = -tmp_x;
   return vec;
 }
 
-static vector_t *vector_multiply_self(vector_t *vec, float value) {
+static vector_t *vector_times_scalar(vector_t *vec, float value)
+{
   vec->x *= value;
   vec->y *= value;
+  return vec;
+}
+
+static vector_t *vector_minus_vector(vector_t *vec, const vector_t *other)
+{
+  vec->x -= other->x;
+  vec->y -= other->y;
+  return vec;
+}
+
+static vector_t *vector_minus_xy(vector_t *vec, float other_x, float other_y)
+{
+  vec->x -= other_x;
+  vec->y -= other_y;
+  return vec;
+}
+
+static vector_t *vector_plus_vector(vector_t *vec, const vector_t *other)
+{
+  vec->x += other->x;
+  vec->y += other->y;
+  return vec;
+}
+
+static vector_t *vector_plus_xy(vector_t *vec, float other_x, float other_y)
+{
+  vec->x += other_x;
+  vec->y += other_y;
   return vec;
 }
 
@@ -36,36 +66,34 @@ static vector_t *vector_multiply_self(vector_t *vec, float value) {
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
  * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawThickLine(SDL_Renderer *render, 
-                       int x1, int y1, int x2, int y2, int thickness, 
-                       int r, int g, int b, int a) {
+void R2D_Canvas_DrawThickLine(SDL_Renderer *render, int x1, int y1, int x2,
+                              int y2, int thickness, int r, int g, int b, int a)
+{
 
-  if (thickness <= 1) {
+  if (thickness <= 1)
     return;
-  }
 
-  vector_t vec = { .x = (x2 - x1), .y = (y2 - y1) };
-  
+  vector_t vec = {.x = (x2 - x1), .y = (y2 - y1)};
+
   // calculate perpendicular with half-thickness in place
-  vector_multiply_self(vector_perpendicular_self(vector_normalize_self(&vec)), thickness / 2.0f);
-  
+  vector_times_scalar(vector_perpendicular(vector_normalize(&vec)),
+                      thickness / 2.0f);
+
   // calculate perp vertices based on thickness
   SDL_Vertex verts[4];
 
-  verts[0].position = (SDL_FPoint) { .x = x1 + vec.x, .y = y1 + vec.y };
-  verts[1].position = (SDL_FPoint) { .x = x2 + vec.x, .y = y2 + vec.y };
-  verts[2].position = (SDL_FPoint) { .x = x2 - vec.x, .y = y2 - vec.y };
-  verts[3].position = (SDL_FPoint) { .x = x1 - vec.x, .y = y1 - vec.y };
+  verts[0].position = (SDL_FPoint){.x = x1 + vec.x, .y = y1 + vec.y};
+  verts[1].position = (SDL_FPoint){.x = x2 + vec.x, .y = y2 + vec.y};
+  verts[2].position = (SDL_FPoint){.x = x2 - vec.x, .y = y2 - vec.y};
+  verts[3].position = (SDL_FPoint){.x = x1 - vec.x, .y = y1 - vec.y};
 
   // set the vertex colour
-  for (register int i=0; i< 4; i++) {
-    verts[i].color = (SDL_Color) {
-      .r = r, .g = g, .b = b, .a = a
-    };
+  for (register int i = 0; i < 4; i++) {
+    verts[i].color = (SDL_Color){.r = r, .g = g, .b = b, .a = a};
   }
 
   // sub-divide the two triangles; we know this is convex
-  int indices[] = { 0, 1, 2, 2, 3, 0 };
+  int indices[] = {0, 1, 2, 2, 3, 0};
   SDL_RenderGeometry(render, NULL, verts, 4, indices, 6);
 }
 
@@ -73,9 +101,10 @@ void R2D_Canvas_DrawThickLine(SDL_Renderer *render,
  * Draw a thick circle on a canvas using a pre-converted RGBA colour value.
  * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawThickCircle(SDL_Renderer *render, 
-                       int x, int y, float radius, float sectors, int thickness, 
-                       int r, int g, int b, int a) {
+void R2D_Canvas_DrawThickCircle(SDL_Renderer *render, int x, int y,
+                                float radius, float sectors, int thickness,
+                                int r, int g, int b, int a)
+{
   if (thickness <= 1) {
     return;
   }
@@ -85,26 +114,21 @@ void R2D_Canvas_DrawThickCircle(SDL_Renderer *render,
   SDL_Vertex verts[4];
 
   // colour all vertices
-  verts[3].color = verts[2].color = verts[1].color = verts[0].color = (SDL_Color) {
-      .r = r, .g = g, .b = b, .a = a
-  };
+  verts[3].color = verts[2].color = verts[1].color = verts[0].color =
+      (SDL_Color){.r = r, .g = g, .b = b, .a = a};
   float half_thick = thickness / 2.0f;
   float outer_radius = radius + half_thick;
   float inner_radius = radius - half_thick;
   float cache_cosf = cosf(0), cache_sinf = sinf(0);
   float angle = 2 * M_PI / sectors;
 
-  int indices[] = { 0, 1, 3, 3, 1, 2 };
+  int indices[] = {0, 1, 3, 3, 1, 2};
 
   // point at 0 radians
-  verts[0].position = (SDL_FPoint) { 
-    .x = x + outer_radius * cache_cosf, 
-    .y = y + outer_radius * cache_sinf
-  };
-  verts[3].position = (SDL_FPoint) { 
-    .x = x + inner_radius * cache_cosf, 
-    .y = y + inner_radius * cache_sinf
-  };
+  verts[0].position = (SDL_FPoint){.x = x + outer_radius * cache_cosf,
+                                   .y = y + outer_radius * cache_sinf};
+  verts[3].position = (SDL_FPoint){.x = x + inner_radius * cache_cosf,
+                                   .y = y + inner_radius * cache_sinf};
   for (float i = 1; i <= sectors; i++) {
     // re-use index 0 and 3 from previous calculation
     verts[1].position = verts[0].position;
@@ -112,14 +136,133 @@ void R2D_Canvas_DrawThickCircle(SDL_Renderer *render,
     // calculate new index 0 and 3 values
     cache_cosf = cosf(i * angle);
     cache_sinf = sinf(i * angle);
-    verts[0].position = (SDL_FPoint) { 
-      .x = x + outer_radius * cache_cosf, 
-      .y = y + outer_radius * cache_sinf
-    };
-    verts[3].position = (SDL_FPoint) { 
-      .x = x + inner_radius * cache_cosf, 
-      .y = y + inner_radius * cache_sinf
-    };
+    verts[0].position = (SDL_FPoint){.x = x + outer_radius * cache_cosf,
+                                     .y = y + outer_radius * cache_sinf};
+    verts[3].position = (SDL_FPoint){.x = x + inner_radius * cache_cosf,
+                                     .y = y + inner_radius * cache_sinf};
     SDL_RenderGeometry(render, NULL, verts, 4, indices, 6);
   }
+}
+
+/*
+ * Compute the intersection between two lines represented by the input line
+ * segments. Unlike a typical line segment collision detector, this function
+ * will find a possible intersection point even if that point is not on either
+ * of the input line "segments". This helps find where two line segments "would"
+ * intersect if they were long enough, in addition to the case when the segments
+ * intersect.
+ * @param line1_p1
+ * @param line1_p2
+ * @param line2_p1
+ * @param line2_p2
+ * @param intersection Pointer into which to write the point of intersection.
+ * @return true if an intersection is found, false if the lines are parallel
+ * (collinear).
+ */
+static bool intersect_two_lines(const vector_t *line1_p1,
+                                const vector_t *line1_p2,
+                                const vector_t *line2_p1,
+                                const vector_t *line2_p2,
+                                vector_t *intersection)
+{
+  vector_t alpha = {.x = line1_p2->x - line1_p1->x,
+                    .y = line1_p2->y - line1_p1->y};
+  vector_t beta = {.x = line2_p1->x - line2_p2->x,
+                   .y = line2_p1->y - line2_p2->y};
+  float denom = (alpha.y * beta.x) - (alpha.x * beta.y);
+
+  if (denom == 0)
+    return false; // collinear
+
+  vector_t theta = {.x = line1_p1->x - line2_p1->x,
+                    .y = line1_p1->y - line2_p1->y};
+  float alpha_numerator = beta.y * theta.x - (beta.x * theta.y);
+  // float beta_numerator = alpha.x * theta.y - (alpha.y * theta.x);
+
+  intersection->x = alpha.x;
+  intersection->y = alpha.y;
+  vector_times_scalar(intersection, alpha_numerator / denom);
+  vector_plus_vector(intersection, line1_p1);
+  return true;
+}
+
+/*
+ * Draw a thick three-point (two line) polyline, with a mitre join where the two
+ * segments are joined.
+ * @param [int] thickness must be > 1, else does nothing
+ */
+void R2D_Canvas_DrawThickPolyline3(SDL_Renderer *render, int x1, int y1, int x2,
+                                   int y2, int x3, int y3, int thickness, int r,
+                                   int g, int b, int a)
+{
+  if (thickness <= 1)
+    return;
+
+  float thick_half = thickness / 2.0f;
+
+  // line one: (x1, y1) -> (x2, y2)
+  // line two: (x2, y2) -> (x3, y3)
+  //
+  // calculate the unit perpendicular for each of the line segments
+  vector_t vec_one_perp = {.x = (x2 - x1), .y = (y2 - y1)};
+  vector_times_scalar(vector_normalize(vector_perpendicular(&vec_one_perp)),
+                      thick_half);
+  vector_t vec_two_perp = {.x = (x3 - x2), .y = (y3 - y2)};
+  vector_times_scalar(vector_normalize(vector_perpendicular(&vec_two_perp)),
+                      thick_half);
+
+  // Prepare to store the different points used map
+  // the triangles that render the thick polyline
+  SDL_Vertex verts[10];
+  // left outer bottom
+  verts[0].position =
+      (SDL_FPoint){.x = x1 + vec_one_perp.x, .y = y1 + vec_one_perp.y};
+  // left outer top
+  verts[1].position =
+      (SDL_FPoint){.x = x2 + vec_one_perp.x, .y = y2 + vec_one_perp.y};
+  // left inner top
+  verts[2].position =
+      (SDL_FPoint){.x = x2 - vec_one_perp.x, .y = y2 - vec_one_perp.y};
+  // left inner bottom
+  verts[3].position =
+      (SDL_FPoint){.x = x1 - vec_one_perp.x, .y = y1 - vec_one_perp.y};
+  // right inner bottom
+  verts[4].position =
+      (SDL_FPoint){.x = x3 - vec_two_perp.x, .y = y3 - vec_two_perp.y};
+  // right outer bottom
+  verts[5].position =
+      (SDL_FPoint){.x = x3 + vec_two_perp.x, .y = y3 + vec_two_perp.y};
+
+  // temporarily calculate the "right inner top" to
+  // figure out the intersection with the "left inner top" which
+  vector_t tmp = {.x = x2 - vec_two_perp.x, .y = y2 - vec_two_perp.y};
+  // find intersection of the left/right inner lines
+  bool has_intersect = intersect_two_lines(
+      &verts[3].position, &verts[2].position, &verts[4].position, &tmp,
+      &verts[2].position // over-write
+  );
+
+  if (has_intersect) {
+    // adjust the "left outer top" point so that it's distance from (x2, y2) is
+    // the same as the left/right "inner top" intersection we calculated above
+    tmp = (vector_t){.x = x2, .y = y2};
+    vector_minus_vector(&tmp, &verts[2].position);
+    verts[1].position = (SDL_FPoint){.x = x2 + tmp.x, .y = y2 + tmp.y};
+
+    // all points have the same colour so
+    int vcount = 6;
+    for (int i = 0; i < vcount; i++) {
+      verts[i].color = (SDL_Color){.r = r, .g = g, .b = b, .a = a};
+    }
+    // setup the index array to define the triangles to render
+    int indices[] = {
+        0, 1, 2, // left outer triangle
+        0, 2, 3, // left inner triangle
+        1, 2, 4, // right inner triangle
+        1, 4, 5, // right outer triangle
+    };
+    SDL_RenderGeometry(render, NULL, verts, vcount, indices, 12);
+  }
+  // else no intersection, which is an extreme case which for now
+  // we will ignore and render nothing.
 }

--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -98,6 +98,57 @@ void R2D_Canvas_DrawThickLine(SDL_Renderer *render, int x1, int y1, int x2,
 }
 
 /*
+ * Draw a thick rectangle on a canvas using a pre-converted RGBA colour value.
+ * @param [int] thickness must be > 1, else does nothing
+ */
+void R2D_Canvas_DrawThickRect(SDL_Renderer *render, int x, int y, int width,
+                              int height, int thickness, int r, int g, int b,
+                              int a)
+{
+  if (thickness <= 1) {
+    return;
+  }
+
+  float half_thick = thickness / 2.0f;
+  SDL_Vertex verts[8];
+
+  // all points have the same colour so
+  verts[0].color = (SDL_Color){.r = r, .g = g, .b = b, .a = a};
+  for (register int i = 1; i < 8; i++) {
+    verts[i].color = verts[0].color;
+  }
+
+  // outer coords
+  verts[0].position = (SDL_FPoint){.x = x - half_thick, .y = y - half_thick};
+  verts[1].position =
+      (SDL_FPoint){.x = x + width + half_thick, .y = y - half_thick};
+  verts[2].position =
+      (SDL_FPoint){.x = x + width + half_thick, .y = y + height + half_thick};
+  verts[3].position =
+      (SDL_FPoint){.x = x - half_thick, .y = y + height + half_thick};
+
+  // inner coords
+  verts[4].position = (SDL_FPoint){.x = x + half_thick, .y = y + half_thick};
+  verts[5].position =
+      (SDL_FPoint){.x = x + width - half_thick, .y = y + half_thick};
+  verts[6].position =
+      (SDL_FPoint){.x = x + width - half_thick, .y = y + height - half_thick};
+  verts[7].position =
+      (SDL_FPoint){.x = x + half_thick, .y = y + height - half_thick};
+
+  int indices[] = {
+      0, 4, 1, // top outer triangle
+      4, 1, 5, //     inner
+      1, 5, 2, // right outer
+      5, 2, 6, //       inner
+      2, 6, 3, // bottom outer
+      6, 3, 7, //        inner
+      3, 7, 0, // left outer
+      7, 0, 4  //      inner
+  };
+  SDL_RenderGeometry(render, NULL, verts, 8, indices, 24);
+}
+/*
  * Draw a thick circle on a canvas using a pre-converted RGBA colour value.
  * @param [int] thickness must be > 1, else does nothing
  */

--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -2,53 +2,36 @@
 
 #include "ruby2d.h"
 
-Uint32 R2D_Canvas_Color2RGBA(SDL_Surface *surf, double r, double g, double b, double a) {
-  return SDL_MapRGBA(surf->format, r * 255, g * 255, b * 255, a * 255);
-}
-
-/*
- * Draw a filled rectangle on a canvas using a pre-converted RGBA colour value.
- */
-void R2D_Canvas_FillRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba) {
-  SDL_Rect rect = { .x = x, .y = y, .w = w, .h = h };
-  SDL_FillRect(surf, &rect, rgba);
-}
-
-/*
- * Draw the outline of a rectangle on a canvas using a pre-converted RGBA colour value.
- */
-void R2D_Canvas_DrawRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba) {
-  SDL_Rect rect = { .x = x, .y = y, .w = w, .h = 1 };
-  SDL_FillRect(surf, &rect, rgba);    // top side
-  rect.h = h; rect.w = 1;
-  SDL_FillRect(surf, &rect, rgba);    // left side
-  rect.x += w - 1;
-  SDL_FillRect(surf, &rect, rgba);    // right side
-  rect.x = x; rect.w = w; rect.h = 1; rect.y += h - 1;
-  SDL_FillRect(surf, &rect, rgba);    // bottom side
-}
-
 /*
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
  */
-void R2D_Canvas_DrawLine_RGBA(SDL_Surface *surf, int x1, int y1, int x2, int y2, int thickness, Uint32 rgba) {
-  double x = x2 - x1;
-  double y = y2 - y1;
-  double length = sqrt(x*x + y*y);
-  double addx = x / length;
-  double addy = y / length;
+void R2D_Canvas_DrawLine(SDL_Renderer *render, int x1, int y1, int x2, int y2, int thickness) {
+  if (thickness == 1) {
+    SDL_RenderDrawLine(render, x1, y1, x2, y2);
+    return;
+  }
+  // TODO replace with a polygon filler for thick lines
+  // ------------
+
+  // thick line, draw using fill rectangles
+  float x = x2 - x1;
+  float y = y2 - y1;
+  float length = sqrt(x*x + y*y);
+  float addx = x / length;
+  float addy = y / length;
   x = x1;
   y = y1;
+  SDL_Rect pixel = { .x = x, .y = y, .w = thickness, .h = thickness };
 
+  // Draw think lines without blending for now
+  SDL_SetRenderDrawBlendMode(render, SDL_BLENDMODE_NONE);
   // Draw the pixel on the canvas
   for (int i = 0; i < length; i += 1) {
-    R2D_Canvas_FillRect_RGBA(
-      surf, x, y,
-      thickness, thickness,  // w & h are same val, the pixel "size" based on thickness
-      rgba
-    );
+    pixel.x = x;
+    pixel.y = y;
+    SDL_RenderFillRect(render, &pixel);
     x += addx;
     y += addy;
   }
-
+  SDL_SetRenderDrawBlendMode(render, SDL_BLENDMODE_BLEND);
 }

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -646,6 +646,66 @@ static R_VAL ruby2d_canvas_ext_draw_line(R_VAL self, R_VAL a) {
   return R_NIL;
 }
 
+/*
+ * Ruby2D::Canvas#self.ext_fill_triangle
+ */
+#if MRUBY
+static R_VAL ruby2d_canvas_ext_fill_triangle(mrb_state* mrb, R_VAL self) {
+  mrb_value a;
+  mrb_get_args(mrb, "o", &a);
+#else
+static R_VAL ruby2d_canvas_ext_fill_triangle(R_VAL self, R_VAL a) {
+#endif
+  // `a` is the array representing the triangle
+
+  SDL_Renderer *render;
+  r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
+
+  SDL_Vertex verts[3];
+
+  #define TRI_VOFS 0
+  verts[0].position = (SDL_FPoint) { 
+    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
+    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
+  };
+  verts[0].color = (SDL_Color) {
+    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
+    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
+    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
+    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
+  };
+
+  #undef TRI_VOFS
+  #define TRI_VOFS 6
+  verts[1].position = (SDL_FPoint) { 
+    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
+    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
+  };
+  verts[1].color = (SDL_Color) {
+    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
+    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
+    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
+    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
+  };
+
+  #undef TRI_VOFS
+  #define TRI_VOFS 12
+  verts[2].position = (SDL_FPoint) { 
+    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
+    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
+  };
+  verts[2].color = (SDL_Color) {
+    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
+    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
+    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
+    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
+  };
+
+  SDL_RenderGeometry(render, NULL, verts, 3, NULL, 0);
+
+  return R_NIL;
+}
+
 
 /*
  * Ruby2D::Sound#ext_init
@@ -1514,6 +1574,9 @@ void Init_ruby2d() {
 
   // Ruby2D::Canvas#ext_draw_line
   r_define_method(ruby2d_canvas_class, "ext_draw_line", ruby2d_canvas_ext_draw_line, r_args_req(1));
+
+  // Ruby2D::Canvas#ext_fill_triangle
+  r_define_method(ruby2d_canvas_class, "ext_fill_triangle", ruby2d_canvas_ext_fill_triangle, r_args_req(1));
 
   // Ruby2D::Window
   R_CLASS ruby2d_window_class = r_define_class(ruby2d_module, "Window");

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -662,45 +662,19 @@ static R_VAL ruby2d_canvas_ext_fill_triangle(R_VAL self, R_VAL a) {
   r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
 
   SDL_Vertex verts[3];
-
-  #define TRI_VOFS 0
-  verts[0].position = (SDL_FPoint) { 
-    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
-    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
-  };
-  verts[0].color = (SDL_Color) {
-    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
-    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
-    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
-    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
-  };
-
-  #undef TRI_VOFS
-  #define TRI_VOFS 6
-  verts[1].position = (SDL_FPoint) { 
-    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
-    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
-  };
-  verts[1].color = (SDL_Color) {
-    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
-    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
-    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
-    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
-  };
-
-  #undef TRI_VOFS
-  #define TRI_VOFS 12
-  verts[2].position = (SDL_FPoint) { 
-    .x = NUM2INT(r_ary_entry(a,  TRI_VOFS + 0)),  // x1
-    .y = NUM2INT(r_ary_entry(a,  TRI_VOFS + 1)),  // y1
-  };
-  verts[2].color = (SDL_Color) {
-    .r = NUM2DBL(r_ary_entry(a, TRI_VOFS + 2)) * 255,
-    .g = NUM2DBL(r_ary_entry(a, TRI_VOFS + 3)) * 255,
-    .b = NUM2DBL(r_ary_entry(a, TRI_VOFS + 4)) * 255,
-    .a = NUM2DBL(r_ary_entry(a, TRI_VOFS + 5)) * 255,
-  };
-
+  for (int vix = 0; vix < 3; vix++) {
+    int vofs = vix * 6;
+    verts[vix].position = (SDL_FPoint) { 
+      .x = NUM2INT(r_ary_entry(a,  vofs + 0)),  // x1
+      .y = NUM2INT(r_ary_entry(a,  vofs + 1)),  // y1
+    };
+    verts[vix].color = (SDL_Color) {
+      .r = NUM2DBL(r_ary_entry(a, vofs + 2)) * 255,
+      .g = NUM2DBL(r_ary_entry(a, vofs + 3)) * 255,
+      .b = NUM2DBL(r_ary_entry(a, vofs + 4)) * 255,
+      .a = NUM2DBL(r_ary_entry(a, vofs + 5)) * 255,
+    };
+  }
   SDL_RenderGeometry(render, NULL, verts, 3, NULL, 0);
 
   return R_NIL;

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -595,24 +595,41 @@ static R_VAL ruby2d_canvas_ext_draw_rectangle(mrb_state* mrb, R_VAL self) {
 static R_VAL ruby2d_canvas_ext_draw_rectangle(R_VAL self, R_VAL a) {
 #endif
   // `a` is the array representing the rectangle
+  //   0, 1,   2,     3,       4,      5, 6, 7, 8
+  // [ x, y, width, height, thickness, r, g, b, a]
 
   SDL_Renderer *render;
   r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
 
-  SDL_Rect rect = { .x = NUM2INT(r_ary_entry(a, 0)),
-                    .y = NUM2INT(r_ary_entry(a, 1)),
-                    .w = NUM2INT(r_ary_entry(a, 2)),
-                    .h = NUM2INT(r_ary_entry(a, 3))
-                    };
+  int thickness = NUM2INT(r_ary_entry(a, 4)); 
+  if (thickness == 1) {
+    SDL_Rect rect = { .x = NUM2INT(r_ary_entry(a, 0)),
+                      .y = NUM2INT(r_ary_entry(a, 1)),
+                      .w = NUM2INT(r_ary_entry(a, 2)),
+                      .h = NUM2INT(r_ary_entry(a, 3))
+                      };
 
-  SDL_SetRenderDrawColor(render,
-          NUM2DBL(r_ary_entry(a, 4)) * 255, // r
-          NUM2DBL(r_ary_entry(a, 5)) * 255, // g
-          NUM2DBL(r_ary_entry(a, 6)) * 255, // b
-          NUM2DBL(r_ary_entry(a, 7)) * 255  // a
-          );
-  SDL_RenderDrawRect(render, &rect);
-
+    SDL_SetRenderDrawColor(render,
+            NUM2DBL(r_ary_entry(a, 5)) * 255, // r
+            NUM2DBL(r_ary_entry(a, 6)) * 255, // g
+            NUM2DBL(r_ary_entry(a, 7)) * 255, // b
+            NUM2DBL(r_ary_entry(a, 8)) * 255  // a
+            );
+    SDL_RenderDrawRect(render, &rect);
+  }
+  else if (thickness > 1) {
+    R2D_Canvas_DrawThickRect(render, 
+      NUM2INT(r_ary_entry(a, 0)), // x
+      NUM2INT(r_ary_entry(a, 1)), // y
+      NUM2INT(r_ary_entry(a, 2)), // width
+      NUM2INT(r_ary_entry(a, 3)), // height
+      thickness,
+      NUM2DBL(r_ary_entry(a, 5)) * 255, // r
+      NUM2DBL(r_ary_entry(a, 6)) * 255, // g
+      NUM2DBL(r_ary_entry(a, 7)) * 255, // b
+      NUM2DBL(r_ary_entry(a, 8)) * 255  // a
+    );
+  }
   return R_NIL;
 }
 

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -630,19 +630,38 @@ static R_VAL ruby2d_canvas_ext_draw_line(R_VAL self, R_VAL a) {
   SDL_Renderer *render;
   r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
 
-  SDL_SetRenderDrawColor(render,
-          NUM2DBL(r_ary_entry(a, 5)) * 255, // r
-          NUM2DBL(r_ary_entry(a, 6)) * 255, // g
-          NUM2DBL(r_ary_entry(a, 7)) * 255, // b
-          NUM2DBL(r_ary_entry(a, 8)) * 255  // a
-          );
-  R2D_Canvas_DrawLine(render, 
-    NUM2INT(r_ary_entry(a, 0)), // x1
-    NUM2INT(r_ary_entry(a, 1)), // y1
-    NUM2INT(r_ary_entry(a, 2)), // x2
-    NUM2INT(r_ary_entry(a, 3)), // y2
-    NUM2INT(r_ary_entry(a, 4))  // thickness
-  );
+  int thickness = NUM2INT(r_ary_entry(a, 4)); 
+  if (thickness == 1) {
+    // use the SDL_Renderer's draw line for single pixel lines
+    SDL_SetRenderDrawColor(render,
+            NUM2DBL(r_ary_entry(a, 5)) * 255, // r
+            NUM2DBL(r_ary_entry(a, 6)) * 255, // g
+            NUM2DBL(r_ary_entry(a, 7)) * 255, // b
+            NUM2DBL(r_ary_entry(a, 8)) * 255  // a
+            );
+    SDL_RenderDrawLine(render, 
+      NUM2INT(r_ary_entry(a, 0)), // x1
+      NUM2INT(r_ary_entry(a, 1)), // y1
+      NUM2INT(r_ary_entry(a, 2)), // x2
+      NUM2INT(r_ary_entry(a, 3))  // y2
+    );
+  }
+  else if (thickness > 1) {
+    // use a custom handler to convert a thick line into a 
+    // quad and draw using SDL_Renderer's geometry renderer
+    R2D_Canvas_DrawThickLine(render, 
+      NUM2INT(r_ary_entry(a, 0)), // x1
+      NUM2INT(r_ary_entry(a, 1)), // y1
+      NUM2INT(r_ary_entry(a, 2)), // x2
+      NUM2INT(r_ary_entry(a, 3)), // y2
+      thickness,
+      NUM2DBL(r_ary_entry(a, 5)) * 255, // r
+      NUM2DBL(r_ary_entry(a, 6)) * 255, // g
+      NUM2DBL(r_ary_entry(a, 7)) * 255, // b
+      NUM2DBL(r_ary_entry(a, 8)) * 255  // a
+    );
+  }
+
   return R_NIL;
 }
 

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -506,24 +506,9 @@ void R2D_FreeSound(R2D_Sound *snd);
 // Canvas //////////////////////////////////////////////////////////////////////
 
 /*
- * Convert colour to a 32-bit RGBA integer
- */
-Uint32 R2D_Canvas_Color2RGBA(SDL_Surface *surf, double r, double g, double b, double a);
-
-/*
- * Draw a rectangle on a canvas using a pre-converted RGBA colour value.
- */
-void R2D_Canvas_FillRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba);
-
-/*
- * Draw the outline of a rectangle on a canvas using a pre-converted RGBA colour value.
- */
-void R2D_Canvas_DrawRect_RGBA(SDL_Surface *surf, int x, int y, int w, int h, Uint32 rgba);
-
-/*
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
  */
-void R2D_Canvas_DrawLine_RGBA(SDL_Surface *surf, int x1, int y1, int x2, int y2, int thickness, Uint32 rgba);
+void R2D_Canvas_DrawLine(SDL_Renderer *render, int x1, int y1, int x2, int y2, int thickness);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -506,6 +506,14 @@ void R2D_FreeSound(R2D_Sound *snd);
 // Canvas //////////////////////////////////////////////////////////////////////
 
 /*
+ * Draw a thick rectangle on a canvas using a pre-converted RGBA colour value.
+ * @param [int] thickness must be > 1, else does nothing
+ */
+void R2D_Canvas_DrawThickRect(SDL_Renderer *render, int x, int y, int width,
+                              int height, int thickness, int r, int g, int b,
+                              int a);
+
+/*
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
  * @param [int] thickness must be > 1, else does nothing
  */

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -522,14 +522,13 @@ void R2D_Canvas_DrawThickCircle(SDL_Renderer *render,
                        int r, int g, int b, int a);
 
 /*
- * Draw a thick three-point (two line) polyline, with a mitre join where the two segments
- * are joined.
+ * Draw a thick N-point polyline, with a mitre join where two
+ * segments are joined.
  * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawThickPolyline3(
-  SDL_Renderer *render, 
-  int x1, int y1, int x2, int y2, int x3, int y3, 
-  int thickness, int r, int g, int b, int a);
+void R2D_Canvas_DrawThickPolyline(SDL_Renderer *render, SDL_FPoint *points,
+                                  int num_points, int thickness, int r, int g,
+                                  int b, int a);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -522,12 +522,20 @@ void R2D_Canvas_DrawThickLine(SDL_Renderer *render,
                        int r, int g, int b, int a);
 
 /*
- * Draw a thick circle on a canvas using a pre-converted RGBA colour value.
+ * Draw a thin (single pixel) ellipse on a canvas using a pre-converted RGBA
+ * colour value.
+ */
+void R2D_Canvas_DrawThinEllipse(SDL_Renderer *render, int x, int y,
+                                float xradius, float yradius, float sectors,
+                                int r, int g, int b, int a);
+
+/*
+ * Draw a thick ellipse on a canvas using a pre-converted RGBA colour value.
  * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawThickCircle(SDL_Renderer *render, 
-                       int x, int y, float radius, float sectors, int thickness, 
-                       int r, int g, int b, int a);
+void R2D_Canvas_DrawThickEllipse(SDL_Renderer *render, int x, int y,
+                                 float xradius, float yradius, float sectors,
+                                 int thickness, int r, int g, int b, int a);
 
 /*
  * Draw a thick N-point polyline, with a mitre join where two

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -507,8 +507,11 @@ void R2D_FreeSound(R2D_Sound *snd);
 
 /*
  * Draw a thick line on a canvas using a pre-converted RGBA colour value.
+ * @param [int] thickness must be > 1, else does nothing
  */
-void R2D_Canvas_DrawLine(SDL_Renderer *render, int x1, int y1, int x2, int y2, int thickness);
+void R2D_Canvas_DrawThickLine(SDL_Renderer *render, 
+                       int x1, int y1, int x2, int y2, int thickness, 
+                       int r, int g, int b, int a);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -513,6 +513,14 @@ void R2D_Canvas_DrawThickLine(SDL_Renderer *render,
                        int x1, int y1, int x2, int y2, int thickness, 
                        int r, int g, int b, int a);
 
+/*
+ * Draw a thick circle on a canvas using a pre-converted RGBA colour value.
+ * @param [int] thickness must be > 1, else does nothing
+ */
+void R2D_Canvas_DrawThickCircle(SDL_Renderer *render, 
+                       int x, int y, float radius, float sectors, int thickness, 
+                       int r, int g, int b, int a);
+
 // Music ///////////////////////////////////////////////////////////////////////
 
 /*

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -521,6 +521,16 @@ void R2D_Canvas_DrawThickCircle(SDL_Renderer *render,
                        int x, int y, float radius, float sectors, int thickness, 
                        int r, int g, int b, int a);
 
+/*
+ * Draw a thick three-point (two line) polyline, with a mitre join where the two segments
+ * are joined.
+ * @param [int] thickness must be > 1, else does nothing
+ */
+void R2D_Canvas_DrawThickPolyline3(
+  SDL_Renderer *render, 
+  int x1, int y1, int x2, int y2, int x3, int y3, 
+  int thickness, int r, int g, int b, int a);
+
 // Music ///////////////////////////////////////////////////////////////////////
 
 /*

--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -533,10 +533,11 @@ void R2D_Canvas_DrawThickCircle(SDL_Renderer *render,
  * Draw a thick N-point polyline, with a mitre join where two
  * segments are joined.
  * @param [int] thickness must be > 1, else does nothing
+ * @param [bool] skip_first_last use false for polyline, true for polygon when specifying first, second points again at the end
  */
 void R2D_Canvas_DrawThickPolyline(SDL_Renderer *render, SDL_FPoint *points,
                                   int num_points, int thickness, int r, int g,
-                                  int b, int a);
+                                  int b, int a, bool skip_first_last);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -93,10 +93,28 @@ module Ruby2D
     def draw_circle(x:, y:, radius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
-      ext_draw_circle([
-                        x, y, radius, sectors, pen_width,
-                        clr.r, clr.g, clr.b, clr.a
-                      ])
+      ext_draw_ellipse([
+                         x, y, radius, radius, sectors, pen_width,
+                         clr.r, clr.g, clr.b, clr.a
+                       ])
+      update_texture if @update
+    end
+
+    # Draw an ellipse
+    # @param [Numeric] x Centre
+    # @param [Numeric] y Centre
+    # @param [Numeric] xradius
+    # @param [Numeric] yradius
+    # @param [Numeric] sectors The number of segments to subdivide the circumference.
+    # @param [Numeric] pen_width The thickness of the circle in pixels
+    # @param [Color] color (or +colour+) The fill colour
+    def draw_ellipse(x:, y:, xradius:, yradius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
+      ext_draw_ellipse([
+                         x, y, xradius, yradius, sectors, pen_width,
+                         clr.r, clr.g, clr.b, clr.a
+                       ])
       update_texture if @update
     end
 
@@ -109,10 +127,27 @@ module Ruby2D
     def fill_circle(x:, y:, radius:, sectors: 30, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
-      ext_fill_circle([
-                        x, y, radius, sectors,
-                        clr.r, clr.g, clr.b, clr.a
-                      ])
+      ext_fill_ellipse([
+                         x, y, radius, radius, sectors,
+                         clr.r, clr.g, clr.b, clr.a
+                       ])
+      update_texture if @update
+    end
+
+    # Draw a filled ellipse.
+    # @param [Numeric] x Centre
+    # @param [Numeric] y Centre
+    # @param [Numeric] xradius
+    # @param [Numeric] yradius
+    # @param [Numeric] sectors The number of segments to subdivide the circumference.
+    # @param [Color] color (or +colour+) The fill colour
+    def fill_ellipse(x:, y:, xradius:, yradius:, sectors: 30, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
+      ext_fill_ellipse([
+                         x, y, xradius, yradius, sectors,
+                         clr.r, clr.g, clr.b, clr.a
+                       ])
       update_texture if @update
     end
 

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -88,7 +88,7 @@ module Ruby2D
     # @param [Numeric] y Centre
     # @param [Numeric] radius
     # @param [Numeric] sectors The number of segments to subdivide the circumference.
-    # @param [Numeric] width The thickness of the circle in pixels
+    # @param [Numeric] pen_width The thickness of the circle in pixels
     # @param [Color] color (or +colour+) The fill colour
     def draw_circle(x:, y:, radius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
@@ -153,13 +153,33 @@ module Ruby2D
     # @param [Numeric] y1
     # @param [Numeric] x2
     # @param [Numeric] y2
-    # @param [Numeric] width The line's thickness in pixels; defaults to 1.
+    # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
     def draw_line(x1:, y1:, x2:, y2:, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_line([
         x1, y1, x2, y2, pen_width,
+        clr.r, clr.g, clr.b, clr.a
+      ])
+      update_texture if @update
+    end
+
+    # Draw a poly-line between three points. 
+    # @note A more general purpose method to draw N-point poly-line will eventually replace this method.
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] x3
+    # @param [Numeric] y3
+    # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
+    # @param [Color] color (or +colour+) The line colour
+    def draw_polyline3(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
+      ext_draw_polyline3([
+        x1, y1, x2, y2, x3, y3, pen_width,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -90,11 +90,11 @@ module Ruby2D
     # @param [Numeric] sectors The number of segments to subdivide the circumference.
     # @param [Numeric] width The thickness of the circle in pixels
     # @param [Color] color (or +colour+) The fill colour
-    def draw_circle(x:, y:, radius:, sectors: 30, width: 1, color: nil, colour: nil)
+    def draw_circle(x:, y:, radius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_circle([
-        x, y, radius, sectors, width,
+        x, y, radius, sectors, pen_width,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update
@@ -155,11 +155,11 @@ module Ruby2D
     # @param [Numeric] y2
     # @param [Numeric] width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
-    def draw_line(x1:, y1:, x2:, y2:, width: 1, color: nil, colour: nil)
+    def draw_line(x1:, y1:, x2:, y2:, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_line([
-        x1, y1, x2, y2, width,
+        x1, y1, x2, y2, pen_width,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -83,6 +83,23 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Draw a circle.
+    # @param [Numeric] x Centre
+    # @param [Numeric] y Centre
+    # @param [Numeric] radius
+    # @param [Numeric] sectors The number of segments to subdivide the circumference.
+    # @param [Numeric] width The thickness of the circle in pixels
+    # @param [Color] color (or +colour+) The fill colour
+    def draw_circle(x:, y:, radius:, sectors: 30, width: 1, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
+      ext_draw_circle([
+        x, y, radius, sectors, width,
+        clr.r, clr.g, clr.b, clr.a
+      ])
+      update_texture if @update
+    end
+
     # Draw a filled circle.
     # @param [Numeric] x Centre
     # @param [Numeric] y Centre

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -83,6 +83,22 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Draw a filled circle.
+    # @param [Numeric] x Centre
+    # @param [Numeric] y Centre
+    # @param [Numeric] radius
+    # @param [Numeric] sectors The number of segments to subdivide the circumference.
+    # @param [Color] color (or +colour+) The fill colour
+    def fill_circle(x:, y:, radius:, sectors: 30, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
+      ext_fill_circle([
+        x, y, radius, sectors,
+        clr.r, clr.g, clr.b, clr.a
+      ])
+      update_texture if @update
+    end
+
     # Draw a filled rectangle.
     # @param [Numeric] x
     # @param [Numeric] y

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -22,37 +22,82 @@ module Ruby2D
     end
     
     # Clear the entire canvas, replacing every pixel with fill colour without blending.
+    # @param [Color] fill_color 
     def clear(fill_color = nil)
       color = fill_color || @fill
       ext_clear([color.r, color.g, color.b, color.a])
       update_texture if @update
     end
 
+    # Draw a filled triangle with a single colour or per-vertex colour blending.
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] x3
+    # @param [Numeric] y3
+    # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
+    def fill_triangle(x1:, y1:, x2:, y2:, x3:, y3:, color: nil, colour:nil)
+      clr = color || colour
+      if clr.is_a? Color::Set
+        c1 = clr[0]
+        c2 = clr[1] || c1
+        c3 = clr[2] || c2
+      else
+        c1 = c2 = c3 = (clr.is_a?(Color) ? clr : Color.new(clr))
+      end
+      ext_fill_triangle([
+        x1, y1, c1.r, c1.g, c1.b, c1.a,
+        x2, y2, c2.r, c2.g, c2.b, c2.a,
+        x3, y3, c3.r, c3.g, c3.b, c3.a
+      ])
+      update_texture if @update
+    end
+
     # Draw a filled rectangle.
-    def fill_rectangle(opts = {})
-      clr = Color.new(opts[:color] || opts[:colour])
+    # @param [Numeric] x
+    # @param [Numeric] y
+    # @param [Numeric] width
+    # @param [Numeric] height
+    # @param [Color] color (or +colour+) The fill colour
+    def fill_rectangle(x:, y:, width:, height:, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
       ext_fill_rectangle([
-        opts[:x], opts[:y], opts[:width], opts[:height],
+        x, y, width, height,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update
     end
 
     # Draw an outline of a rectangle
-    def draw_rectangle(opts = {})
-      clr = Color.new(opts[:color] || opts[:colour])
+    # @param [Numeric] x
+    # @param [Numeric] y
+    # @param [Numeric] width
+    # @param [Numeric] height
+    # @param [Color] color (or +colour+) The line colour
+    def draw_rectangle(x:, y:, width:, height:, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_rectangle([
-        opts[:x], opts[:y], opts[:width], opts[:height],
+        x, y, width, height,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update
     end
 
-    # Draw a straight line
-    def draw_line(opts = {})
-      clr = Color.new(opts[:color] || opts[:colour])
+    # Draw a straight line between two points
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] width The line's thickness in pixels; defaults to 1.
+    # @param [Color] color (or +colour+) The line colour
+    def draw_line(x1:, y1:, x2:, y2:, width: 1, color: nil, colour: nil)
+      clr = color || colour
+      clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_line([
-        opts[:x1], opts[:y1], opts[:x2], opts[:y2], opts[:width],
+        x1, y1, x2, y2, width,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -132,6 +132,38 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Draw an outline of a triangle.
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] x3
+    # @param [Numeric] y3
+    # @param [Numeric] pen_width The thickness of the rectangle in pixels
+    # @param [Color] color (or +colour+) The line colour
+    def draw_triangle(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour:nil)
+      draw_polyline closed:true, 
+                        coordinates: [x1, y1, x2, y2, x3, y3],
+                        color: color, colour: colour, pen_width: pen_width
+    end
+
+    # Draw an outline of a quad.
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] x3
+    # @param [Numeric] y3
+    # @param [Numeric] x4
+    # @param [Numeric] y4
+    # @param [Numeric] pen_width The thickness of the rectangle in pixels
+    # @param [Color] color (or +colour+) The line colour
+    def draw_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, pen_width: 1, color: nil, colour:nil)
+      draw_polyline closed:true, 
+                        coordinates: [x1, y1, x2, y2, x3, y3, x4, y4],
+                        color: color, colour: colour, pen_width: pen_width
+    end
+
     # Draw an outline of a rectangle
     # @param [Numeric] x
     # @param [Numeric] y
@@ -171,12 +203,17 @@ module Ruby2D
     # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
     # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
-    def draw_polyline(coordinates:, pen_width: 1, color: nil, colour: nil)
+    # @param [Boolean] closed Use +true+ to draw this as a closed shape
+    def draw_polyline(coordinates:, pen_width: 1, color: nil, colour: nil, closed: false)
       return if coordinates.nil? || coordinates.count < 6
 
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
-      ext_draw_polyline([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
+      if closed
+        ext_draw_polygon([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
+      else
+        ext_draw_polyline([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
+      end
       update_texture if @update
     end
 

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -54,6 +54,35 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Draw a filled quad(rilateral) with a single colour or per-vertex colour blending.
+    # @param [Numeric] x1
+    # @param [Numeric] y1
+    # @param [Numeric] x2
+    # @param [Numeric] y2
+    # @param [Numeric] x3
+    # @param [Numeric] y3
+    # @param [Numeric] x4
+    # @param [Numeric] y4
+    # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
+    def fill_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, color: nil, colour:nil)
+      clr = color || colour
+      if clr.is_a? Color::Set
+        c1 = clr[0]
+        c2 = clr[1] || c1
+        c3 = clr[2] || c2
+        c4 = clr[3] || c3
+      else
+        c1 = c2 = c3 = c4 = (clr.is_a?(Color) ? clr : Color.new(clr))
+      end
+      ext_fill_quad([
+        x1, y1, c1.r, c1.g, c1.b, c1.a,
+        x2, y2, c2.r, c2.g, c2.b, c2.a,
+        x3, y3, c3.r, c3.g, c3.b, c3.a,
+        x4, y4, c4.r, c4.g, c4.b, c4.a
+      ])
+      update_texture if @update
+    end
+
     # Draw a filled rectangle.
     # @param [Numeric] x
     # @param [Numeric] y

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -21,6 +21,13 @@ module Ruby2D
       unless opts[:show] == false then add end
     end
     
+    # Clear the entire canvas, replacing every pixel with fill colour without blending.
+    def clear(fill_color = nil)
+      color = fill_color || @fill
+      ext_clear([color.r, color.g, color.b, color.a])
+      update_texture if @update
+    end
+
     # Draw a filled rectangle.
     def fill_rectangle(opts = {})
       clr = Color.new(opts[:color] || opts[:colour])

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -4,26 +4,28 @@ module Ruby2D
   class Canvas
     include Renderable
 
-    def initialize(opts = {})
-      @x = opts[:x] || 0
-      @y = opts[:y] || 0
-      @z = opts[:z] || 0
-      @width = opts[:width]
-      @height = opts[:height]
-      @rotate = opts[:rotate] || 0
-      @fill = Color.new(opts[:fill] || [0, 0, 0, 0])
-      self.color = opts[:color] || opts[:colour] || 'white'
-      self.color.opacity = opts[:opacity] if opts[:opacity]
-      @update = if opts[:update] == nil then true else opts[:update] end
+    def initialize(width:, height:, x: 0, y: 0, z: 0, rotate: 0,
+                   fill: [0, 0, 0, 0], color: nil, colour: nil, opacity: nil,
+                   update: true, show: true)
+      @x = x
+      @y = y
+      @z = z
+      @width = width
+      @height = height
+      @rotate = rotate
+      @fill = Color.new(fill)
+      self.color = color || colour || 'white'
+      color.opacity = opacity if opacity
+      @update = update
 
-      ext_create([@width, @height, @fill.r, @fill.g, @fill.b, @fill.a])  # sets @ext_pixel_data
+      ext_create([@width, @height, @fill.r, @fill.g, @fill.b, @fill.a]) # sets @ext_pixel_data
       @texture = Texture.new(@ext_pixel_data, @width, @height)
-      unless opts[:show] == false then add end
+      add if show
     end
-    
+
     # Clear the entire canvas, replacing every pixel with fill colour without blending.
-    # @param [Color] fill_color 
-    def clear(fill_color = nil)
+    # @param [Color] fill_color
+    def clear(fill_color = @fill)
       color = fill_color || @fill
       ext_clear([color.r, color.g, color.b, color.a])
       update_texture if @update
@@ -37,7 +39,7 @@ module Ruby2D
     # @param [Numeric] x3
     # @param [Numeric] y3
     # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
-    def fill_triangle(x1:, y1:, x2:, y2:, x3:, y3:, color: nil, colour:nil)
+    def fill_triangle(x1:, y1:, x2:, y2:, x3:, y3:, color: nil, colour: nil)
       clr = color || colour
       if clr.is_a? Color::Set
         c1 = clr[0]
@@ -47,10 +49,10 @@ module Ruby2D
         c1 = c2 = c3 = (clr.is_a?(Color) ? clr : Color.new(clr))
       end
       ext_fill_triangle([
-        x1, y1, c1.r, c1.g, c1.b, c1.a,
-        x2, y2, c2.r, c2.g, c2.b, c2.a,
-        x3, y3, c3.r, c3.g, c3.b, c3.a
-      ])
+                          x1, y1, c1.r, c1.g, c1.b, c1.a,
+                          x2, y2, c2.r, c2.g, c2.b, c2.a,
+                          x3, y3, c3.r, c3.g, c3.b, c3.a
+                        ])
       update_texture if @update
     end
 
@@ -64,7 +66,7 @@ module Ruby2D
     # @param [Numeric] x4
     # @param [Numeric] y4
     # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
-    def fill_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, color: nil, colour:nil)
+    def fill_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, color: nil, colour: nil)
       clr = color || colour
       if clr.is_a? Color::Set
         c1 = clr[0]
@@ -74,12 +76,10 @@ module Ruby2D
       else
         c1 = c2 = c3 = c4 = (clr.is_a?(Color) ? clr : Color.new(clr))
       end
-      ext_fill_quad([
-        x1, y1, c1.r, c1.g, c1.b, c1.a,
-        x2, y2, c2.r, c2.g, c2.b, c2.a,
-        x3, y3, c3.r, c3.g, c3.b, c3.a,
-        x4, y4, c4.r, c4.g, c4.b, c4.a
-      ])
+      ext_fill_quad([x1, y1, c1.r, c1.g, c1.b, c1.a,
+                     x2, y2, c2.r, c2.g, c2.b, c2.a,
+                     x3, y3, c3.r, c3.g, c3.b, c3.a,
+                     x4, y4, c4.r, c4.g, c4.b, c4.a])
       update_texture if @update
     end
 
@@ -94,9 +94,9 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_circle([
-        x, y, radius, sectors, pen_width,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+                        x, y, radius, sectors, pen_width,
+                        clr.r, clr.g, clr.b, clr.a
+                      ])
       update_texture if @update
     end
 
@@ -110,9 +110,9 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_fill_circle([
-        x, y, radius, sectors,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+                        x, y, radius, sectors,
+                        clr.r, clr.g, clr.b, clr.a
+                      ])
       update_texture if @update
     end
 
@@ -126,9 +126,9 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_fill_rectangle([
-        x, y, width, height,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+                           x, y, width, height,
+                           clr.r, clr.g, clr.b, clr.a
+                         ])
       update_texture if @update
     end
 
@@ -141,10 +141,10 @@ module Ruby2D
     # @param [Numeric] y3
     # @param [Numeric] pen_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_triangle(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour:nil)
-      draw_polyline closed:true, 
-                        coordinates: [x1, y1, x2, y2, x3, y3],
-                        color: color, colour: colour, pen_width: pen_width
+    def draw_triangle(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour: nil)
+      draw_polyline closed: true,
+                    coordinates: [x1, y1, x2, y2, x3, y3],
+                    color: color, colour: colour, pen_width: pen_width
     end
 
     # Draw an outline of a quad.
@@ -158,10 +158,10 @@ module Ruby2D
     # @param [Numeric] y4
     # @param [Numeric] pen_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, pen_width: 1, color: nil, colour:nil)
-      draw_polyline closed:true, 
-                        coordinates: [x1, y1, x2, y2, x3, y3, x4, y4],
-                        color: color, colour: colour, pen_width: pen_width
+    def draw_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, pen_width: 1, color: nil, colour: nil)
+      draw_polyline closed: true,
+                    coordinates: [x1, y1, x2, y2, x3, y3, x4, y4],
+                    color: color, colour: colour, pen_width: pen_width
     end
 
     # Draw an outline of a rectangle
@@ -175,9 +175,9 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_rectangle([
-        x, y, width, height, pen_width,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+                           x, y, width, height, pen_width,
+                           clr.r, clr.g, clr.b, clr.a
+                         ])
       update_texture if @update
     end
 
@@ -192,13 +192,13 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_line([
-        x1, y1, x2, y2, pen_width,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+                      x1, y1, x2, y2, pen_width,
+                      clr.r, clr.g, clr.b, clr.a
+                    ])
       update_texture if @update
     end
 
-    # Draw a poly-line between N points. 
+    # Draw a poly-line between N points.
     # @note A more general purpose method to draw N-point poly-line will eventually replace this method.
     # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
     # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
@@ -210,9 +210,9 @@ module Ruby2D
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       if closed
-        ext_draw_polygon([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
+        ext_draw_polygon([pen_width, clr.r, clr.g, clr.b, clr.a], coordinates)
       else
-        ext_draw_polyline([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
+        ext_draw_polyline([pen_width, clr.r, clr.g, clr.b, clr.a], coordinates)
       end
       update_texture if @update
     end
@@ -235,6 +235,5 @@ module Ruby2D
         vertices.coordinates, vertices.texture_coordinates, color
       )
     end
-
   end
 end

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -165,23 +165,17 @@ module Ruby2D
       update_texture if @update
     end
 
-    # Draw a poly-line between three points. 
+    # Draw a poly-line between N points. 
     # @note A more general purpose method to draw N-point poly-line will eventually replace this method.
-    # @param [Numeric] x1
-    # @param [Numeric] y1
-    # @param [Numeric] x2
-    # @param [Numeric] y2
-    # @param [Numeric] x3
-    # @param [Numeric] y3
+    # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
     # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
-    def draw_polyline3(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour: nil)
+    def draw_polyline(coordinates:, pen_width: 1, color: nil, colour: nil)
+      return if coordinates.nil? || coordinates.count < 6
+
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
-      ext_draw_polyline3([
-        x1, y1, x2, y2, x3, y3, pen_width,
-        clr.r, clr.g, clr.b, clr.a
-      ])
+      ext_draw_polyline([pen_width,clr.r, clr.g, clr.b, clr.a], coordinates)
       update_texture if @update
     end
 

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -137,12 +137,13 @@ module Ruby2D
     # @param [Numeric] y
     # @param [Numeric] width
     # @param [Numeric] height
+    # @param [Numeric] pen_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_rectangle(x:, y:, width:, height:, color: nil, colour: nil)
+    def draw_rectangle(x:, y:, width:, height:, pen_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_rectangle([
-        x, y, width, height,
+        x, y, width, height, pen_width,
         clr.r, clr.g, clr.b, clr.a
       ])
       update_texture if @update

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -11,6 +11,7 @@ Square.new(size: 500, color: 'red')
 canvas = Canvas.new(x: 50, y: 50, width: Window.width - 100, height: Window.height - 100, fill: [1, 1, 1, 0.5])
 
 clear_between_draw = false
+draw_shape = :square
 
 update do
   canvas.clear if clear_between_draw
@@ -21,11 +22,20 @@ update do
     color: [rand, rand, rand, 1]
   )
 
-  canvas.fill_rectangle(
-    x: Window.mouse_x - 50 + 5, y: Window.mouse_y - 50 + 5,
-    width: 40, height: 40,
-    color: [rand, rand, rand, 1]
-  )
+  case draw_shape
+  when :circle
+    canvas.fill_circle(
+      x: Window.mouse_x - 25, y: Window.mouse_y - 25,
+      radius: 20, sectors: 10,
+      color: [rand, rand, rand, 1]
+    )
+  else
+    canvas.fill_rectangle(
+      x: Window.mouse_x - 50 + 5, y: Window.mouse_y - 50 + 5,
+      width: 40, height: 40,
+      color: [rand, rand, rand, 1]
+    )
+  end
 
   canvas.draw_line(
     x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, width: 1,
@@ -33,10 +43,16 @@ update do
   )
 end
 
+#
+# Press space to enable/disable clearing between frame while moving the mouse
+# Press s to switch between square and circle
+#
 on :key_down do |event|
   case event.key
   when 'escape'
     close
+  when 's'
+    draw_shape = draw_shape == :square ? :circle : :square
   when 'space'
     clear_between_draw = !clear_between_draw
   end

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -42,7 +42,7 @@ update do
   end
 
   canvas.draw_line(
-    x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, width: 1,
+    x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, pen_width: 1,
     color: [rand, rand, rand, 1]
   )
 end

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -16,20 +16,24 @@ draw_shape = :square
 update do
   canvas.clear if clear_between_draw
 
-  canvas.draw_rectangle(
-    x: Window.mouse_x - 50, y: Window.mouse_y - 50,
-    width: 50, height: 50,
-    color: [rand, rand, rand, 1]
-  )
-
   case draw_shape
   when :circle
+    canvas.draw_circle(
+      x: Window.mouse_x - 25, y: Window.mouse_y - 25,
+      radius: 25, sectors: 10,
+      color: [rand, rand, rand, 1]
+    )
     canvas.fill_circle(
       x: Window.mouse_x - 25, y: Window.mouse_y - 25,
       radius: 20, sectors: 10,
       color: [rand, rand, rand, 1]
     )
   else
+    canvas.draw_rectangle(
+      x: Window.mouse_x - 50, y: Window.mouse_y - 50,
+      width: 50, height: 50,
+      color: [rand, rand, rand, 1]
+    )
     canvas.fill_rectangle(
       x: Window.mouse_x - 50 + 5, y: Window.mouse_y - 50 + 5,
       width: 40, height: 40,

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -10,7 +10,11 @@ Square.new(size: 500, color: 'red')
 # If `update: false` is set, `canvas.update` must be manually called to update the rendered texture
 canvas = Canvas.new(x: 50, y: 50, width: Window.width - 100, height: Window.height - 100, fill: [1, 1, 1, 0.5])
 
+clear_between_draw = false
+
 update do
+  canvas.clear if clear_between_draw
+
   canvas.draw_rectangle(
     x: Window.mouse_x - 50, y: Window.mouse_y - 50,
     width: 50, height: 50,
@@ -30,7 +34,12 @@ update do
 end
 
 on :key_down do |event|
-  close if event.key == 'escape'
+  case event.key
+  when 'escape'
+    close
+  when 'space'
+    clear_between_draw = !clear_between_draw
+  end
   canvas.update
 end
 

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -39,10 +39,32 @@ end
 canvas.fill_triangle x1: 100, y1: 100, x2: 200, y2: 150, x3: 150, y3: 400,
                      color: [1, 1, 1, 0.5]
 
-canvas.fill_triangle x1: 300, y1: 100, x2: 400, y2: 150, x3: 350, y3: 400,
+canvas.fill_triangle x1: 250, y1: 100, x2: 350, y2: 150, x3: 300, y3: 400,
                      color: Color::Set.new([[1, 0, 0, 0.5],
                                             [0, 1, 0, 0.5],
                                             [0, 0, 1, 0.5]])
+
+canvas.fill_rectangle(x: 400 - 5, y: 200 - 5, width: 10, height: 10, color: 'white')
+canvas.fill_rectangle(x: 450 - 5, y: 150 - 5, width: 10, height: 10, color: 'white')
+canvas.fill_rectangle(x: 500 - 5, y: 300 - 5, width: 10, height: 10, color: 'white')
+canvas.fill_rectangle(x: 450 - 5, y: 190 - 5, width: 10, height: 10, color: 'white')
+
+canvas.fill_quad x1: 400, y1: 200,
+                 x2: 450, y2: 150,
+                 x3: 500, y3: 300,
+                 x4: 450, y4: 190,
+                 color: [0, 0, 1, 0.5]
+
+canvas.fill_quad x1: 500, y1: 200,
+                 x2: 550, y2: 150,
+                 x3: 600, y3: 300,
+                 x4: 550, y4: 400,
+                 color: Color::Set.new([
+                                         [1, 0, 0, 0.5],
+                                         [0, 1, 0, 0.5],
+                                         [0, 0, 1, 0.5],
+                                         [0, 1, 1, 0.5]
+                                       ])
 
 update do
   canvas.update

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -23,9 +23,16 @@ canvas = Canvas.new(x: 50, y: 50,
 end
 
 canvas.fill_circle(
-  x: 300, y: 300, radius: 200,
+  x: 175, y: 350, radius: 150,
   color: [0.9, 0.9, 0.9, 0.3]
 )
+
+[1, 3, 5, 7, 9].each do |ix|
+  canvas.draw_circle(
+    x: 175, y: 350, radius: 150 - (ix * ix), width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
+    color: [1, 1, 1, 0.5]
+  )
+end
 
 (1..3).each do |ix|
   # thick line

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -36,6 +36,14 @@ end
   )
 end
 
+canvas.fill_triangle x1: 100, y1: 100, x2: 200, y2: 150, x3: 150, y3: 400,
+                     color: [1, 1, 1, 0.5]
+
+canvas.fill_triangle x1: 300, y1: 100, x2: 400, y2: 150, x3: 350, y3: 400,
+                     color: Color::Set.new([[1, 0, 0, 0.5],
+                                            [0, 1, 0, 0.5],
+                                            [0, 0, 1, 0.5]])
+
 update do
   canvas.update
 end

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -20,6 +20,12 @@ canvas = Canvas.new(x: 50, y: 50,
     width: 100, height: 100,
     color: Color.new([0, 1, 0, 0.5])
   )
+  canvas.draw_rectangle(
+    x: 10 + ix * 30, y: 10 + ix * 30,
+    width: 100, height: 100,
+    pen_width: 8,
+    color: Color.new([0, 0, 1, 0.25])
+  )
 end
 
 canvas.fill_circle(

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -22,10 +22,8 @@ canvas = Canvas.new(x: 50, y: 50,
   )
 end
 
-#
-# Currently fat lines don't blend so we don't get the
-# same effect ... yet.
 (1..3).each do |ix|
+  # thick line
   canvas.draw_line(
     x1: 10,
     y1: 75 + (ix * 15),
@@ -33,6 +31,14 @@ end
     y2: 420 + (ix * 15),
     width: 30,
     color: Color.new([0.5 + (ix * 0.1), 0.5 + (ix * 0.1), 1, 0.5])
+  )
+  # thin line along the middle of the thick line
+  canvas.draw_line(
+    x1: 10,
+    y1: 75 + (ix * 15),
+    x2: 310,
+    y2: 420 + (ix * 15),
+    color: 'white'
   )
 end
 

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -89,13 +89,19 @@ canvas.fill_quad x1: 500, y1: 200,
                                          [0, 1, 1, 0.5]
                                        ])
 
-canvas.draw_polyline3 x1: 300, y1: 300, x2: 550, y2: 200, x3: 500, y3: 450,
-                      pen_width: 20,
-                      color: [1, 1, 1, 0.5]
+polyline = [400, 100,
+            500, 200,
+            400, 300,
+            500, 400,
+            600, 100]
 
-canvas.draw_polyline3 x1: 300, y1: 300, x2: 550, y2: 200, x3: 500, y3: 450,
-                      pen_width: 1,
-                      color: [1, 1, 1, 1]
+canvas.draw_polyline coordinates: polyline,
+                     pen_width: 20,
+                     color: [1, 1, 1, 0.5]
+
+canvas.draw_polyline coordinates: polyline,
+                     pen_width: 1,
+                     color: [1, 1, 1, 1]
 
 update do
   canvas.update

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -29,7 +29,8 @@ canvas.fill_circle(
 
 [1, 3, 5, 7, 9].each do |ix|
   canvas.draw_circle(
-    x: 175, y: 350, radius: 150 - (ix * ix), width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
+    x: 175, y: 350, radius: 150 - (ix * ix), 
+    pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
     color: [1, 1, 1, 0.5]
   )
 end
@@ -41,7 +42,7 @@ end
     y1: 75 + (ix * 15),
     x2: 310,
     y2: 420 + (ix * 15),
-    width: 30,
+    pen_width: 30,
     color: Color.new([0.5 + (ix * 0.1), 0.5 + (ix * 0.1), 1, 0.5])
   )
   # thin line along the middle of the thick line

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -33,11 +33,24 @@ canvas.fill_circle(
   color: [0.9, 0.9, 0.9, 0.3]
 )
 
-[1, 3, 5, 7, 9].each do |ix|
+canvas.fill_ellipse(
+  x: 475, y: 50, xradius: 50, yradius: 35,
+  color: [0.9, 0.7, 0.5, 0.6]
+)
+
+[1, 5, 9].each do |ix|
   canvas.draw_circle(
     x: 175, y: 350, radius: 150 - (ix * ix),
     pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
     color: [1, 1, 1, 0.5]
+  )
+end
+
+[3, 7].each do |ix|
+  canvas.draw_ellipse(
+    x: 175, y: 350, xradius: 150 - (ix * ix), yradius: 100 - (ix * ix),
+    pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
+    color: [0.8, 1, 0.6, 0.5]
   )
 end
 

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -22,6 +22,11 @@ canvas = Canvas.new(x: 50, y: 50,
   )
 end
 
+canvas.fill_circle(
+  x: 300, y: 300, radius: 200,
+  color: [0.9, 0.9, 0.9, 0.3]
+)
+
 (1..3).each do |ix|
   # thick line
   canvas.draw_line(
@@ -60,6 +65,10 @@ canvas.fill_quad x1: 400, y1: 200,
                  x3: 500, y3: 300,
                  x4: 450, y4: 190,
                  color: [0, 0, 1, 0.5]
+
+canvas.fill_circle x: 450, y: 250,
+                   radius: 100,
+                   color: [0, 0.7, 1, 0.3]
 
 canvas.fill_quad x1: 500, y1: 200,
                  x2: 550, y2: 150,

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -63,6 +63,8 @@ end
 
 canvas.fill_triangle x1: 100, y1: 100, x2: 200, y2: 150, x3: 150, y3: 400,
                      color: [1, 1, 1, 0.5]
+canvas.draw_triangle x1: 100 - 5, y1: 100 - 5, x2: 200 + 5, y2: 150 - 5, x3: 150, y3: 400 + 5,
+                     color: [1, 1, 1, 0.75], pen_width: 10
 
 canvas.fill_triangle x1: 250, y1: 100, x2: 350, y2: 150, x3: 300, y3: 400,
                      color: Color::Set.new([[1, 0, 0, 0.5],
@@ -83,6 +85,12 @@ canvas.fill_quad x1: 400, y1: 200,
 canvas.fill_circle x: 450, y: 250,
                    radius: 100,
                    color: [0, 0.7, 1, 0.3]
+
+canvas.draw_quad x1: 500 - 5, y1: 200 - 5,
+                 x2: 550 + 5, y2: 150 - 5,
+                 x3: 600 + 5, y3: 300,
+                 x4: 550, y4: 400 + 5,
+                 color: [1, 1, 1, 0.75], pen_width: 5
 
 canvas.fill_quad x1: 500, y1: 200,
                  x2: 550, y2: 150,
@@ -108,6 +116,15 @@ canvas.draw_polyline coordinates: polyline,
 canvas.draw_polyline coordinates: polyline,
                      pen_width: 1,
                      color: [1, 1, 1, 1]
+
+polygon = [500, 100,
+           600, 200,
+           500, 300,
+           300, 300]
+
+canvas.draw_polyline coordinates: polygon,
+                     pen_width: 20, closed: true,
+                     color: [0, 1, 1, 0.25]
 
 update do
   canvas.update

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -1,0 +1,48 @@
+require 'ruby2d'
+
+set width: 800
+set height: 600
+
+Square.new(size: 500, color: 'red')
+
+# Canvas options:
+#  x, y, z, width, height, rotate, fill, color, update
+# If `update: false` is set, `canvas.update` must be manually called to update the rendered texture
+canvas = Canvas.new(x: 50, y: 50,
+                    width: Window.width - 100,
+                    height: Window.height - 100,
+                    fill: [1, 1, 1, 0.5],
+                    update: false)
+
+(1..10).each do |ix|
+  canvas.fill_rectangle(
+    x: 10 + ix * 30, y: 10 + ix * 30,
+    width: 100, height: 100,
+    color: Color.new([0, 1, 0, 0.5])
+  )
+end
+
+#
+# Currently fat lines don't blend so we don't get the
+# same effect ... yet.
+(1..3).each do |ix|
+  canvas.draw_line(
+    x1: 10,
+    y1: 75 + (ix * 15),
+    x2: 310,
+    y2: 420 + (ix * 15),
+    width: 30,
+    color: Color.new([0.5 + (ix * 0.1), 0.5 + (ix * 0.1), 1, 0.5])
+  )
+end
+
+update do
+  canvas.update
+end
+
+on :key_down do |event|
+  close if event.key == 'escape'
+  canvas.update
+end
+
+show

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -29,7 +29,7 @@ canvas.fill_circle(
 
 [1, 3, 5, 7, 9].each do |ix|
   canvas.draw_circle(
-    x: 175, y: 350, radius: 150 - (ix * ix), 
+    x: 175, y: 350, radius: 150 - (ix * ix),
     pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
     color: [1, 1, 1, 0.5]
   )
@@ -88,6 +88,14 @@ canvas.fill_quad x1: 500, y1: 200,
                                          [0, 0, 1, 0.5],
                                          [0, 1, 1, 0.5]
                                        ])
+
+canvas.draw_polyline3 x1: 300, y1: 300, x2: 550, y2: 200, x3: 500, y3: 450,
+                      pen_width: 20,
+                      color: [1, 1, 1, 0.5]
+
+canvas.draw_polyline3 x1: 300, y1: 300, x2: 550, y2: 200, x3: 500, y3: 450,
+                      pen_width: 1,
+                      color: [1, 1, 1, 1]
 
 update do
   canvas.update

--- a/test/canvas_linejoin.rb
+++ b/test/canvas_linejoin.rb
@@ -1,0 +1,59 @@
+require 'ruby2d'
+
+set width: 800
+set height: 600
+
+Square.new(size: 500, color: 'red')
+
+# Canvas options:
+#  x, y, z, width, height, rotate, fill, color, update
+# If `update: false` is set, `canvas.update` must be manually called to update the rendered texture
+canvas = Canvas.new(x: 50, y: 50, width: Window.width - 100, height: Window.height - 100, fill: [1, 1, 1, 0.5])
+
+points = [
+  { x: 300, y: 300 },
+  { x: 550, y: 200 },
+  { x: 500, y: 450 }
+]
+control_index = 2
+
+update do
+  canvas.clear
+
+  points[control_index][:x] = Window.mouse_x - 50
+  points[control_index][:y] = Window.mouse_y - 50
+
+  canvas.draw_polyline3 x1: points[0][:x], y1: points[0][:y],
+                        x2: points[1][:x], y2: points[1][:y],
+                        x3: points[2][:x], y3: points[2][:y],
+                        pen_width: 20,
+                        color: [1, 1, 1, 0.5]
+
+  canvas.draw_polyline3 x1: points[0][:x], y1: points[0][:y],
+                        x2: points[1][:x], y2: points[1][:y],
+                        x3: points[2][:x], y3: points[2][:y],
+                        pen_width: 1,
+                        color: [1, 1, 1, 1]
+end
+
+#
+# Press space to enable/disable clearing between frame while moving the mouse
+# Press s to switch between square and circle
+#
+on :key_down do |event|
+  case event.key
+  when 'escape'
+    close
+  when '0', '1', '2'
+    control_index = event.key.to_i
+  end
+end
+
+puts '
+Press Esc to exit.
+Press 0 to select the first point to manipulate
+Press 1 to select second (middle) point
+Press 2 to select third (last) point <-- default
+'
+
+show

--- a/test/canvas_linejoin.rb
+++ b/test/canvas_linejoin.rb
@@ -11,9 +11,11 @@ Square.new(size: 500, color: 'red')
 canvas = Canvas.new(x: 50, y: 50, width: Window.width - 100, height: Window.height - 100, fill: [1, 1, 1, 0.5])
 
 points = [
-  { x: 300, y: 300 },
-  { x: 550, y: 200 },
-  { x: 500, y: 450 }
+  { x: 200, y: 200 },
+  { x: 350, y: 100 },
+  { x: 400, y: 250 },
+  { x: 350, y: 350 },
+  { x: 300, y: 400 }
 ]
 control_index = 2
 
@@ -23,17 +25,19 @@ update do
   points[control_index][:x] = Window.mouse_x - 50
   points[control_index][:y] = Window.mouse_y - 50
 
-  canvas.draw_polyline3 x1: points[0][:x], y1: points[0][:y],
-                        x2: points[1][:x], y2: points[1][:y],
-                        x3: points[2][:x], y3: points[2][:y],
-                        pen_width: 20,
-                        color: [1, 1, 1, 0.5]
+  polyline = [points[0][:x], points[0][:y],
+              points[1][:x], points[1][:y],
+              points[2][:x], points[2][:y],
+              points[3][:x], points[3][:y],
+              points[4][:x], points[4][:y]]
 
-  canvas.draw_polyline3 x1: points[0][:x], y1: points[0][:y],
-                        x2: points[1][:x], y2: points[1][:y],
-                        x3: points[2][:x], y3: points[2][:y],
-                        pen_width: 1,
-                        color: [1, 1, 1, 1]
+  canvas.draw_polyline coordinates: polyline,
+                       pen_width: 20,
+                       color: [1, 1, 1, 0.5]
+
+  canvas.draw_polyline coordinates: polyline,
+                       pen_width: 1,
+                       color: [1, 1, 1, 1]
 end
 
 #
@@ -44,16 +48,14 @@ on :key_down do |event|
   case event.key
   when 'escape'
     close
-  when '0', '1', '2'
-    control_index = event.key.to_i
+  when '1', '2', '3', '4', '5'
+    control_index = event.key.to_i - 1
   end
 end
 
 puts '
 Press Esc to exit.
-Press 0 to select the first point to manipulate
-Press 1 to select second (middle) point
-Press 2 to select third (last) point <-- default
+Press 1, 2, ... to select the first, second ... points to manipulate with the mouse
 '
 
 show

--- a/test/canvas_linejoin.rb
+++ b/test/canvas_linejoin.rb
@@ -18,6 +18,7 @@ points = [
   { x: 300, y: 400 }
 ]
 control_index = 2
+closed_shape = false
 
 update do
   canvas.clear
@@ -33,11 +34,13 @@ update do
 
   canvas.draw_polyline coordinates: polyline,
                        pen_width: 20,
-                       color: [1, 1, 1, 0.5]
+                       color: [1, 1, 1, 0.5],
+                       closed: closed_shape
 
   canvas.draw_polyline coordinates: polyline,
                        pen_width: 1,
-                       color: [1, 1, 1, 1]
+                       color: [1, 1, 1, 1],
+                       closed: closed_shape
 end
 
 #
@@ -48,6 +51,8 @@ on :key_down do |event|
   case event.key
   when 'escape'
     close
+  when 'c'
+    closed_shape = !closed_shape
   when '1', '2', '3', '4', '5'
     control_index = event.key.to_i - 1
   end
@@ -55,6 +60,7 @@ end
 
 puts '
 Press Esc to exit.
+Press C or c to toggle closing the polyline (i.e. polyine vs polygon)
 Press 1, 2, ... to select the first, second ... points to manipulate with the mouse
 '
 


### PR DESCRIPTION
@blacktm, this refactors Canvas implementation to use `SDL_Renderer` since it supports a software-based renderer with alpha blending support, and provides some drawing primitives that we don't have to reinvent. 

* Added following fill methods
  * `fill_triangle` and `fill_quad` methods for a single triangle and quadrilateral respectively, with vertex colouring. 
  * `fill_circle` with a single colour
  * `fill_ellipse` with a single colour
* Added folowing draw methods
  * `draw_circle` with "pen width" support
    * Renamed `width` -> `pen_width` to avoid ambiguity with shape dimension in other methods
  * `draw_polyline` with "pen_width" support 
    * with `closed:` param that can be set to `true` to draw polygon outlines
  * `draw_triangle` and `draw_quad` with pen width (using closed polylines)
  * `draw_ellipse` with pen width
* Refactored methods
  * `draw_line` to handle thick lines
    * Renamed `width` -> `pen_width` to avoid ambiguity with shape dimension in other methods
  * `draw_rectangle` to support pen width
  * Replaced `opts={}` params with explicit keyword params
* Updated `canvas` test: 
  * use "space" to enable/disable clearing between frames
  * use "s" key to change the shape following the mouse between square and circle  
* Added tests
  * `canvas_blend` test to verify all the supported shape methods
  * `canvas_linejoin` interactive test to verify `polyline` mitre joining by controlling each point with mouse (use number keys to select point)

> FYI this has been tested with `ruby` and `mruby` on my M1-based Macbook and not on any other platforms. 

<img width="657" alt="Screen Shot 2022-04-28 at 18 12 36" src="https://user-images.githubusercontent.com/19142777/165856410-3b5c91d9-ec31-4dbf-987e-2b0cd6a329ec.png">
