### PR TITLE
Add canvas fill polygon

### DIFF
--- a/ext/ruby2d/ruby2d.h
+++ b/ext/ruby2d/ruby2d.h
@@ -547,6 +547,19 @@ void R2D_Canvas_DrawThickPolyline(SDL_Renderer *render, SDL_FPoint *points,
                                   int num_points, int thickness, int r, int g,
                                   int b, int a, bool skip_first_last);
 
+/*
+ * Fill a polygon with a single colour.
+ * @param points Array of points
+ * @param num_points Number of points
+ * @param colors Array of colours
+ * @param num_colors Number of colors, must be at least 1, and may be less than
+ *                      +num_points+ in which case the colours will be repeated
+ *                      via modulo.
+ * @note Currently supports only: convex polygons or simple polygons with one concave corner. For now.
+ */
+void R2D_Canvas_FillPolygon(SDL_Renderer *render, SDL_FPoint *points,
+                            int num_points, SDL_Color *colors, int num_colors);
+
 // Music ///////////////////////////////////////////////////////////////////////
 
 /*

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -234,7 +234,6 @@ module Ruby2D
     end
 
     # Draw a poly-line between N points.
-    # @note A more general purpose method to draw N-point poly-line will eventually replace this method.
     # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
     # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
@@ -252,11 +251,39 @@ module Ruby2D
       update_texture if @update
     end
 
+    # Fill a polygon made up of N points.
+    # @note Currently only supports convex polygons or simple polygons with one concave corner.
+    # @note Supports per-vertex coloring, but the triangulation may change and affect the coloring.
+    # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
+    # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour; at least one colour must be specified.
+    def fill_polygon(coordinates:, color: nil, colour: nil)
+      return if coordinates.nil? || coordinates.count < 6 || (color.nil? && colour.nil?)
+
+      ext_fill_polygon(coordinates, colors_to_a(color || colour))
+      update_texture if @update
+    end
+
     def update
       update_texture
     end
 
     private
+
+    # Converts +color_or_set+ as a sequence of colour components; e.g. +[ r1, g1, b1, a1, ...]+
+    # @param [Color, Color::Set] color_or_set
+    # @return an array of r, g, b, a values
+    def colors_to_a(color_or_set)
+      if color_or_set.is_a? Color::Set
+        color_a = []
+        color_or_set.each do |clr|
+          color_a << clr.r << clr.g << clr.b << clr.a
+        end
+        return color_a
+      end
+
+      color_or_set = Color.new(color_or_set) unless color_or_set.is_a? Color
+      color_or_set.to_a
+    end
 
     def update_texture
       @texture.delete

--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -1,20 +1,39 @@
 # Ruby2D::Color
 
-require 'forwardable'
-
 module Ruby2D
   class Color
 
     # Color::Set represents an array of colors
     class Set
       include Enumerable
-      extend Forwardable
 
       def initialize(colors)
         @colors = colors.map { |c| Color.new(c) }
       end
 
-      def_delegators :@colors, :[], :length, :count, :each, :first, :last
+      def [](index)
+        @colors[index]
+      end
+
+      def length
+        @colors.length
+      end
+
+      alias count length
+
+      def each
+        @colors.each do |c|
+          yield c
+        end
+      end
+
+      def first
+        @colors.first
+      end
+
+      def last
+        @colors.last
+      end
 
       def opacity
         @colors.first.opacity

--- a/lib/ruby2d/color.rb
+++ b/lib/ruby2d/color.rb
@@ -1,23 +1,24 @@
 # Ruby2D::Color
 
+require 'forwardable'
+
 module Ruby2D
   class Color
 
     # Color::Set represents an array of colors
     class Set
+      include Enumerable
+      extend Forwardable
+
       def initialize(colors)
         @colors = colors.map { |c| Color.new(c) }
       end
 
-      def [](i)
-        @colors[i]
-      end
+      def_delegators :@colors, :[], :length, :count, :each, :first, :last
 
-      def length
-        @colors.length
+      def opacity
+        @colors.first.opacity
       end
-
-      def opacity; @colors[0].opacity end
 
       def opacity=(opacity)
         @colors.each do |color|
@@ -104,6 +105,11 @@ module Ruby2D
     # Convenience methods to alias `opacity` to `@a`
     def opacity; @a end
     def opacity=(opacity); @a = opacity end
+
+    # Retiurn colour components as an array +[r, g, b, a]+
+    def to_a
+      [@r, @g, @b, @a]
+    end
 
     private
 

--- a/test/canvas_polygon.rb
+++ b/test/canvas_polygon.rb
@@ -1,0 +1,64 @@
+require 'ruby2d'
+
+set width: 800
+set height: 600
+
+Square.new(size: 500, color: 'red')
+
+# Canvas options:
+#  x, y, z, width, height, rotate, fill, color, update
+# If `update: false` is set, `canvas.update` must be manually called to update the rendered texture
+canvas = Canvas.new(x: 50, y: 50, width: Window.width - 100, height: Window.height - 100, fill: [1, 1, 1, 0.5])
+
+points = [
+  { x: 200, y: 200 },
+  { x: 350, y: 100 },
+  { x: 400, y: 250 },
+  { x: 350, y: 350 },
+  { x: 300, y: 400 }
+]
+control_index = -1
+
+update do
+  canvas.clear
+
+  unless control_index.negative?
+    points[control_index][:x] = Window.mouse_x - 50
+    points[control_index][:y] = Window.mouse_y - 50
+
+    canvas.fill_circle x: points[control_index][:x], y: points[control_index][:y], radius: 20, color: 'lime'
+  end
+
+  polyline = [points[0][:x], points[0][:y],
+              points[1][:x], points[1][:y],
+              points[2][:x], points[2][:y],
+              points[3][:x], points[3][:y],
+              points[4][:x], points[4][:y]]
+
+  canvas.fill_polygon coordinates: polyline, color: Color::Set.new(%w[red green blue yellow black])
+
+  canvas.draw_polyline coordinates: polyline,
+                       pen_width: 1,
+                       color: [1, 0, 0, 1],
+                       closed: true
+end
+
+#
+# Press space to enable/disable clearing between frame while moving the mouse
+# Press s to switch between square and circle
+#
+on :key_down do |event|
+  case event.key
+  when 'escape'
+    close
+  when '1', '2', '3', '4', '5'
+    control_index = event.key.to_i - 1
+  end
+end
+
+puts '
+Press Esc to exit.
+Press 1, 2, ... to select the first, second ... points to manipulate with the mouse
+'
+
+show


### PR DESCRIPTION
@blacktm, this PR adds `Canvas#fill_polygon` that handles convex polygons (and simple polygons with one convex corner for now.) It also includes vertex coloring, though I have to point out that the triangulation affects the rendering and so we might need to consider something more sophisticated (e.g. mesh vs minimal triangulation) at some point. Specifying one colour value (i.e. not a `Color::Set`) will work by filling with a single colour.

This includes some tweaks to `Color::Set`: since I needed to enumerate it; it now implements `Enumerable` and exposes a more `Array` methods.

There is a new interactive test called `canvas_polygon` which you can run and then use keys 1, 2, ... to select a vertex to manipulate the shape; this will reveal the non-convex scenarios where we get degenerate behaviour.
