### PR TITLE
Fill quad tri use fill polygon

### DIFF
--- a/ext/ruby2d/canvas.c
+++ b/ext/ruby2d/canvas.c
@@ -79,7 +79,8 @@ typedef enum { CONCAVE = -1, INVALID, CONVEX } poly_type_e;
 static int count_concave_corners(const SDL_FPoint *points, int num_points,
                                  int *pconcave_ix, const int max_pconcave)
 {
-  if (num_points < 3)
+  // triangles are always convex
+  if (num_points <= 3)
     return (0);
 
   int nconcave = 0;
@@ -148,7 +149,7 @@ static void fill_concave1pt_polygon(SDL_Renderer *render,
   SDL_Vertex verts[3];
 
   verts[0].position = points[anchor_ix];
-  verts[0].color = colors[anchor_ix];
+  verts[0].color = colors[anchor_ix % num_colors];
   anchor_ix = (anchor_ix + 1) % num_points;
   for (int i = 2; i < num_points; i++) {
     verts[1].position = points[anchor_ix];
@@ -176,10 +177,17 @@ static void fill_concave1pt_polygon(SDL_Renderer *render,
 void R2D_Canvas_FillPolygon(SDL_Renderer *render, SDL_FPoint *points,
                             int num_points, SDL_Color *colors, int num_colors)
 {
+  if (num_points < 3)
+    return;
+
   // poly_type_e type = polygon_type(points, num_points);
   int concave_point_indices[MAX_CONCAVE_POINT_INDICES];
-  int nconcave = count_concave_corners(
-      points, num_points, concave_point_indices, MAX_CONCAVE_POINT_INDICES);
+
+  int nconcave =
+      num_points == 3
+          ? 0 // triangles are always convex
+          : count_concave_corners(points, num_points, concave_point_indices,
+                                  MAX_CONCAVE_POINT_INDICES);
 
   if (nconcave == 0) {
     // convex

--- a/ext/ruby2d/ruby2d.c
+++ b/ext/ruby2d/ruby2d.c
@@ -995,40 +995,6 @@ static R_VAL ruby2d_canvas_ext_draw_ellipse(R_VAL self, R_VAL a) {
 }
 
 /*
- * Ruby2D::Canvas#self.ext_fill_triangle
- */
-#if MRUBY
-static R_VAL ruby2d_canvas_ext_fill_triangle(mrb_state* mrb, R_VAL self) {
-  mrb_value a;
-  mrb_get_args(mrb, "o", &a);
-#else
-static R_VAL ruby2d_canvas_ext_fill_triangle(R_VAL self, R_VAL a) {
-#endif
-  // `a` is the array representing the triangle
-
-  SDL_Renderer *render;
-  r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
-
-  SDL_Vertex verts[3];
-  for (int vix = 0; vix < 3; vix++) {
-    int vofs = vix * 6;
-    verts[vix].position = (SDL_FPoint) { 
-      .x = NUM2INT(r_ary_entry(a,  vofs + 0)),  // x1
-      .y = NUM2INT(r_ary_entry(a,  vofs + 1)),  // y1
-    };
-    verts[vix].color = (SDL_Color) {
-      .r = NUM2DBL(r_ary_entry(a, vofs + 2)) * 255,
-      .g = NUM2DBL(r_ary_entry(a, vofs + 3)) * 255,
-      .b = NUM2DBL(r_ary_entry(a, vofs + 4)) * 255,
-      .a = NUM2DBL(r_ary_entry(a, vofs + 5)) * 255,
-    };
-  }
-  SDL_RenderGeometry(render, NULL, verts, 3, NULL, 0);
-
-  return R_NIL;
-}
-
-/*
  * Calculate the cross product of the two lines
  * connecting the three points clock-wise. A negative value
  * means the angle "to the right" is > 180. 
@@ -1040,67 +1006,6 @@ static inline int cross_product_corner(x1, y1, x2, y2, x3, y3) {
   register int vec2_y = y2 - y3;
 
   return (vec1_x * vec2_y) - (vec1_y * vec2_x);
-}
-
-/*
- * Ruby2D::Canvas#self.ext_fill_quad
- */
-#if MRUBY
-static R_VAL ruby2d_canvas_ext_fill_quad(mrb_state* mrb, R_VAL self) {
-  mrb_value a;
-  mrb_get_args(mrb, "o", &a);
-#else
-static R_VAL ruby2d_canvas_ext_fill_quad(R_VAL self, R_VAL a) {
-#endif
-  // `a` is the array representing the quad
-
-  SDL_Renderer *render;
-  r_data_get_struct(self, "@ext_renderer", &renderer_data_type, SDL_Renderer, render);
-
-  // Setup the vertices from incoming arguments
-  SDL_Vertex verts[4];
-  for (int vix = 0, vofs = 0; vix < 4; vix++, vofs += 6) {
-    verts[vix].position = (SDL_FPoint) { 
-      .x = NUM2INT(r_ary_entry(a,  vofs + 0)),  // x1
-      .y = NUM2INT(r_ary_entry(a,  vofs + 1)),  // y1
-    };
-    verts[vix].color = (SDL_Color) {
-      .r = NUM2DBL(r_ary_entry(a, vofs + 2)) * 255,
-      .g = NUM2DBL(r_ary_entry(a, vofs + 3)) * 255,
-      .b = NUM2DBL(r_ary_entry(a, vofs + 4)) * 255,
-      .a = NUM2DBL(r_ary_entry(a, vofs + 5)) * 255,
-    };
-  }
-  // Check all the corners to determine if the quad is convex or not
-  bool convex = true;
-  int vix = 0;
-  for (; vix < 4; vix ++) {
-    int v0 = vix < 1 ? 3 : vix - 1; // previous corner
-    int v1 = vix;
-    int v2 = vix == 3 ? 0 : vix + 1;  // next corner
-    int cross = cross_product_corner(
-      verts[v0].position.x, verts[v0].position.y,
-      verts[v1].position.x, verts[v1].position.y,
-      verts[v2].position.x, verts[v2].position.y);
-    if (cross < 0) {
-      convex = false;
-      break;
-    }
-  }
-  if (convex) vix = 0;  // start at first vertex if convex
-  // else start at concave vertex
-
-  int triangle_corners[6] = { 
-    vix,
-    (vix+1) % 4,
-    (vix+2) % 4,
-    (vix+2) % 4,
-    (vix+3) % 4,
-    (vix+4) % 4,
-  };
-  SDL_RenderGeometry(render, NULL, verts, 4, triangle_corners, 6);
-
-  return R_NIL;
 }
 
 /*
@@ -1980,17 +1885,11 @@ void Init_ruby2d() {
   // Ruby2D::Canvas#ext_fill_polygon
   r_define_method(ruby2d_canvas_class, "ext_fill_polygon", ruby2d_canvas_ext_fill_polygon, r_args_req(2));
 
-  // Ruby2D::Canvas#ext_fill_triangle
-  r_define_method(ruby2d_canvas_class, "ext_fill_triangle", ruby2d_canvas_ext_fill_triangle, r_args_req(1));
-
   // Ruby2D::Canvas#ext_fill_ellipse
   r_define_method(ruby2d_canvas_class, "ext_fill_ellipse", ruby2d_canvas_ext_fill_ellipse, r_args_req(1));
 
   // Ruby2D::Canvas#ext_draw_ellipse
   r_define_method(ruby2d_canvas_class, "ext_draw_ellipse", ruby2d_canvas_ext_draw_ellipse, r_args_req(1));
-
-  // Ruby2D::Canvas#ext_fill_quad
-  r_define_method(ruby2d_canvas_class, "ext_fill_quad", ruby2d_canvas_ext_fill_quad, r_args_req(1));
 
   // Ruby2D::Window
   R_CLASS ruby2d_window_class = r_define_class(ruby2d_module, "Window");

--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -40,20 +40,7 @@ module Ruby2D
     # @param [Numeric] y3
     # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
     def fill_triangle(x1:, y1:, x2:, y2:, x3:, y3:, color: nil, colour: nil)
-      clr = color || colour
-      if clr.is_a? Color::Set
-        c1 = clr[0]
-        c2 = clr[1] || c1
-        c3 = clr[2] || c2
-      else
-        c1 = c2 = c3 = (clr.is_a?(Color) ? clr : Color.new(clr))
-      end
-      ext_fill_triangle([
-                          x1, y1, c1.r, c1.g, c1.b, c1.a,
-                          x2, y2, c2.r, c2.g, c2.b, c2.a,
-                          x3, y3, c3.r, c3.g, c3.b, c3.a
-                        ])
-      update_texture if @update
+      fill_polygon coordinates: [x1, y1, x2, y2, x3, y3], color: color || colour
     end
 
     # Draw a filled quad(rilateral) with a single colour or per-vertex colour blending.
@@ -67,20 +54,7 @@ module Ruby2D
     # @param [Numeric] y4
     # @param [Color, Color::Set] color (or +colour+) Set one or per-vertex colour
     def fill_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, color: nil, colour: nil)
-      clr = color || colour
-      if clr.is_a? Color::Set
-        c1 = clr[0]
-        c2 = clr[1] || c1
-        c3 = clr[2] || c2
-        c4 = clr[3] || c3
-      else
-        c1 = c2 = c3 = c4 = (clr.is_a?(Color) ? clr : Color.new(clr))
-      end
-      ext_fill_quad([x1, y1, c1.r, c1.g, c1.b, c1.a,
-                     x2, y2, c2.r, c2.g, c2.b, c2.a,
-                     x3, y3, c3.r, c3.g, c3.b, c3.a,
-                     x4, y4, c4.r, c4.g, c4.b, c4.a])
-      update_texture if @update
+      fill_polygon coordinates: [x1, y1, x2, y2, x3, y3, x4, y4], color: color || colour
     end
 
     # Draw a circle.
@@ -243,10 +217,11 @@ module Ruby2D
 
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
+      config = [pen_width, clr.r, clr.g, clr.b, clr.a]
       if closed
-        ext_draw_polygon([pen_width, clr.r, clr.g, clr.b, clr.a], coordinates)
+        ext_draw_polygon(config, coordinates)
       else
-        ext_draw_polyline([pen_width, clr.r, clr.g, clr.b, clr.a], coordinates)
+        ext_draw_polyline(config, coordinates)
       end
       update_texture if @update
     end
@@ -259,7 +234,8 @@ module Ruby2D
     def fill_polygon(coordinates:, color: nil, colour: nil)
       return if coordinates.nil? || coordinates.count < 6 || (color.nil? && colour.nil?)
 
-      ext_fill_polygon(coordinates, colors_to_a(color || colour))
+      colors = colors_to_a(color || colour)
+      ext_fill_polygon(coordinates, colors)
       update_texture if @update
     end
 

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -99,11 +99,11 @@ canvas.fill_circle x: 450, y: 250,
                    radius: 100,
                    color: [0, 0.7, 1, 0.3]
 
-canvas.draw_quad x1: 500 - 5, y1: 200 - 5,
-                 x2: 550 + 5, y2: 150 - 5,
-                 x3: 600 + 5, y3: 300,
-                 x4: 550, y4: 400 + 5,
-                 color: [1, 1, 1, 0.75], pen_width: 5
+canvas.draw_quad x1: 500, y1: 200,
+                 x2: 550, y2: 150,
+                 x3: 600, y3: 300,
+                 x4: 550, y4: 400,
+                 color: [1, 1, 1, 0.75], pen_width: 10
 
 canvas.fill_quad x1: 500, y1: 200,
                  x2: 550, y2: 150,


### PR DESCRIPTION
@blacktm, a couple of tweaks to Canvas

- Canvas `fill_quad` and `fill_triangle` call `fill_polygon` instead of shape-specific native methods
- Removed `ext_fill_quad` and `ext_fill_triangle` code; the polygon filler gives us a single place to render these, less surface area to fix
- Small tweak to native `R2D_Canvas_FillPolygon` to detect triangle and fast track to convex filler; this could be short-circuited even better if needed later.