### PR TITLE
Rename `pen_width` to `stroke_width`

### DIFF
--- a/lib/ruby2d/canvas.rb
+++ b/lib/ruby2d/canvas.rb
@@ -62,13 +62,13 @@ module Ruby2D
     # @param [Numeric] y Centre
     # @param [Numeric] radius
     # @param [Numeric] sectors The number of segments to subdivide the circumference.
-    # @param [Numeric] pen_width The thickness of the circle in pixels
+    # @param [Numeric] stroke_width The thickness of the circle in pixels
     # @param [Color] color (or +colour+) The fill colour
-    def draw_circle(x:, y:, radius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
+    def draw_circle(x:, y:, radius:, sectors: 30, stroke_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_ellipse([
-                         x, y, radius, radius, sectors, pen_width,
+                         x, y, radius, radius, sectors, stroke_width,
                          clr.r, clr.g, clr.b, clr.a
                        ])
       update_texture if @update
@@ -80,13 +80,13 @@ module Ruby2D
     # @param [Numeric] xradius
     # @param [Numeric] yradius
     # @param [Numeric] sectors The number of segments to subdivide the circumference.
-    # @param [Numeric] pen_width The thickness of the circle in pixels
+    # @param [Numeric] stroke_width The thickness of the circle in pixels
     # @param [Color] color (or +colour+) The fill colour
-    def draw_ellipse(x:, y:, xradius:, yradius:, sectors: 30, pen_width: 1, color: nil, colour: nil)
+    def draw_ellipse(x:, y:, xradius:, yradius:, sectors: 30, stroke_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_ellipse([
-                         x, y, xradius, yradius, sectors, pen_width,
+                         x, y, xradius, yradius, sectors, stroke_width,
                          clr.r, clr.g, clr.b, clr.a
                        ])
       update_texture if @update
@@ -148,12 +148,12 @@ module Ruby2D
     # @param [Numeric] y2
     # @param [Numeric] x3
     # @param [Numeric] y3
-    # @param [Numeric] pen_width The thickness of the rectangle in pixels
+    # @param [Numeric] stroke_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_triangle(x1:, y1:, x2:, y2:, x3:, y3:, pen_width: 1, color: nil, colour: nil)
+    def draw_triangle(x1:, y1:, x2:, y2:, x3:, y3:, stroke_width: 1, color: nil, colour: nil)
       draw_polyline closed: true,
                     coordinates: [x1, y1, x2, y2, x3, y3],
-                    color: color, colour: colour, pen_width: pen_width
+                    color: color, colour: colour, stroke_width: stroke_width
     end
 
     # Draw an outline of a quad.
@@ -165,12 +165,12 @@ module Ruby2D
     # @param [Numeric] y3
     # @param [Numeric] x4
     # @param [Numeric] y4
-    # @param [Numeric] pen_width The thickness of the rectangle in pixels
+    # @param [Numeric] stroke_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, pen_width: 1, color: nil, colour: nil)
+    def draw_quad(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, stroke_width: 1, color: nil, colour: nil)
       draw_polyline closed: true,
                     coordinates: [x1, y1, x2, y2, x3, y3, x4, y4],
-                    color: color, colour: colour, pen_width: pen_width
+                    color: color, colour: colour, stroke_width: stroke_width
     end
 
     # Draw an outline of a rectangle
@@ -178,13 +178,13 @@ module Ruby2D
     # @param [Numeric] y
     # @param [Numeric] width
     # @param [Numeric] height
-    # @param [Numeric] pen_width The thickness of the rectangle in pixels
+    # @param [Numeric] stroke_width The thickness of the rectangle in pixels
     # @param [Color] color (or +colour+) The line colour
-    def draw_rectangle(x:, y:, width:, height:, pen_width: 1, color: nil, colour: nil)
+    def draw_rectangle(x:, y:, width:, height:, stroke_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_rectangle([
-                           x, y, width, height, pen_width,
+                           x, y, width, height, stroke_width,
                            clr.r, clr.g, clr.b, clr.a
                          ])
       update_texture if @update
@@ -195,13 +195,13 @@ module Ruby2D
     # @param [Numeric] y1
     # @param [Numeric] x2
     # @param [Numeric] y2
-    # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
+    # @param [Numeric] stroke_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
-    def draw_line(x1:, y1:, x2:, y2:, pen_width: 1, color: nil, colour: nil)
+    def draw_line(x1:, y1:, x2:, y2:, stroke_width: 1, color: nil, colour: nil)
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
       ext_draw_line([
-                      x1, y1, x2, y2, pen_width,
+                      x1, y1, x2, y2, stroke_width,
                       clr.r, clr.g, clr.b, clr.a
                     ])
       update_texture if @update
@@ -209,15 +209,15 @@ module Ruby2D
 
     # Draw a poly-line between N points.
     # @param [Array] coordinates An array of numbers x1, y1, x2, y2 ... with at least three coordinates (6 values)
-    # @param [Numeric] pen_width The line's thickness in pixels; defaults to 1.
+    # @param [Numeric] stroke_width The line's thickness in pixels; defaults to 1.
     # @param [Color] color (or +colour+) The line colour
     # @param [Boolean] closed Use +true+ to draw this as a closed shape
-    def draw_polyline(coordinates:, pen_width: 1, color: nil, colour: nil, closed: false)
+    def draw_polyline(coordinates:, stroke_width: 1, color: nil, colour: nil, closed: false)
       return if coordinates.nil? || coordinates.count < 6
 
       clr = color || colour
       clr = Color.new(clr) unless clr.is_a? Color
-      config = [pen_width, clr.r, clr.g, clr.b, clr.a]
+      config = [stroke_width, clr.r, clr.g, clr.b, clr.a]
       if closed
         ext_draw_polygon(config, coordinates)
       else

--- a/test/canvas.rb
+++ b/test/canvas.rb
@@ -42,7 +42,7 @@ update do
   end
 
   canvas.draw_line(
-    x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, pen_width: 1,
+    x1: 0, y1: 0, x2: Window.mouse_x - 50, y2: Window.mouse_y - 50, stroke_width: 1,
     color: [rand, rand, rand, 1]
   )
 end

--- a/test/canvas_blend.rb
+++ b/test/canvas_blend.rb
@@ -23,7 +23,7 @@ canvas = Canvas.new(x: 50, y: 50,
   canvas.draw_rectangle(
     x: 10 + ix * 30, y: 10 + ix * 30,
     width: 100, height: 100,
-    pen_width: 8,
+    stroke_width: 8,
     color: Color.new([0, 0, 1, 0.25])
   )
 end
@@ -41,7 +41,7 @@ canvas.fill_ellipse(
 [1, 5, 9].each do |ix|
   canvas.draw_circle(
     x: 175, y: 350, radius: 150 - (ix * ix),
-    pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
+    stroke_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
     color: [1, 1, 1, 0.5]
   )
 end
@@ -49,7 +49,7 @@ end
 [3, 7].each do |ix|
   canvas.draw_ellipse(
     x: 175, y: 350, xradius: 150 - (ix * ix), yradius: 100 - (ix * ix),
-    pen_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
+    stroke_width: ix > 1 ? ix * 2 : 1, sectors: 50 - ix,
     color: [0.8, 1, 0.6, 0.5]
   )
 end
@@ -61,7 +61,7 @@ end
     y1: 75 + (ix * 15),
     x2: 310,
     y2: 420 + (ix * 15),
-    pen_width: 30,
+    stroke_width: 30,
     color: Color.new([0.5 + (ix * 0.1), 0.5 + (ix * 0.1), 1, 0.5])
   )
   # thin line along the middle of the thick line
@@ -77,7 +77,7 @@ end
 canvas.fill_triangle x1: 100, y1: 100, x2: 200, y2: 150, x3: 150, y3: 400,
                      color: [1, 1, 1, 0.5]
 canvas.draw_triangle x1: 100 - 5, y1: 100 - 5, x2: 200 + 5, y2: 150 - 5, x3: 150, y3: 400 + 5,
-                     color: [1, 1, 1, 0.75], pen_width: 10
+                     color: [1, 1, 1, 0.75], stroke_width: 10
 
 canvas.fill_triangle x1: 250, y1: 100, x2: 350, y2: 150, x3: 300, y3: 400,
                      color: Color::Set.new([[1, 0, 0, 0.5],
@@ -103,7 +103,7 @@ canvas.draw_quad x1: 500, y1: 200,
                  x2: 550, y2: 150,
                  x3: 600, y3: 300,
                  x4: 550, y4: 400,
-                 color: [1, 1, 1, 0.75], pen_width: 10
+                 color: [1, 1, 1, 0.75], stroke_width: 10
 
 canvas.fill_quad x1: 500, y1: 200,
                  x2: 550, y2: 150,
@@ -123,11 +123,11 @@ polyline = [400, 100,
             600, 100]
 
 canvas.draw_polyline coordinates: polyline,
-                     pen_width: 20,
+                     stroke_width: 20,
                      color: [1, 1, 1, 0.5]
 
 canvas.draw_polyline coordinates: polyline,
-                     pen_width: 1,
+                     stroke_width: 1,
                      color: [1, 1, 1, 1]
 
 polygon = [500, 100,
@@ -136,7 +136,7 @@ polygon = [500, 100,
            300, 300]
 
 canvas.draw_polyline coordinates: polygon,
-                     pen_width: 20, closed: true,
+                     stroke_width: 20, closed: true,
                      color: [0, 1, 1, 0.25]
 
 update do

--- a/test/canvas_linejoin.rb
+++ b/test/canvas_linejoin.rb
@@ -33,12 +33,12 @@ update do
               points[4][:x], points[4][:y]]
 
   canvas.draw_polyline coordinates: polyline,
-                       pen_width: 20,
+                       stroke_width: 20,
                        color: [1, 1, 1, 0.5],
                        closed: closed_shape
 
   canvas.draw_polyline coordinates: polyline,
-                       pen_width: 1,
+                       stroke_width: 1,
                        color: [1, 1, 1, 1],
                        closed: closed_shape
 end

--- a/test/canvas_polygon.rb
+++ b/test/canvas_polygon.rb
@@ -38,7 +38,7 @@ update do
   canvas.fill_polygon coordinates: polyline, color: Color::Set.new(%w[red green blue yellow black])
 
   canvas.draw_polyline coordinates: polyline,
-                       pen_width: 1,
+                       stroke_width: 1,
                        color: [1, 0, 0, 1],
                        closed: true
 end


### PR DESCRIPTION
Rename `pen_width` parameter to `stroke_width` (with default value of 1); the term `stroke` is commonly used across vector drawing APIs.