### PR TITLE
Draft: Rubocop config and example

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,36 @@
+Naming/MethodParameterName:
+  inherit_mode:
+    override:
+      - Include
+  AllowedNames:
+    - x
+    - y
+    - z
+    - x1
+    - y1
+    - x2
+    - y2
+    - x3
+    - y3
+    - x4
+    - y4
+    - dx
+    - dy
+    - dz
+    - as
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+  Max: 1024
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/MethodLength:
+  Max: 32
+
+Metrics/ParameterLists:
+  Max: 16
+  

--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -1,27 +1,35 @@
+# frozen_string_literal: true
+
 # Ruby2D::Font
 
 module Ruby2D
+  #
+  # Font represents a single typeface in a specific size and style.
+  # Use +Font.load+ to load/retrieve a +Font+ instance by path, size and style.
   class Font
     FONT_CACHE_LIMIT = 100
 
-    @@loaded_fonts = {}
-
     attr_reader :ttf_font
 
-    def initialize(path, size, style=nil)
-      @ttf_font = Font.ext_load(path, size, style.to_s)
-    end
+    # Font cannot be instantiated directly; use +Font.load+ instead.
+    private_class_method :new
+
+    # Cache loaded fonts in a class variable
+    @loaded_fonts = {}
 
     class << self
-      def load(path, size, style=nil)
-        unless File.exist? path
-          raise Error, "Cannot find font file `#{path}`"
-        end
+      # Return a font by +path+, +size+ and +style+, loading the font if not already in the cache.
+      #
+      # @param [String] path Full path to the font file
+      # @param [Numeric] size Size of font to setup
+      # @param [String] style Font style
+      #
+      # @return [Font]
+      def load(path, size, style = nil)
+        raise Error, "Cannot find font file `#{path}`" unless File.exist? path
 
-        (@@loaded_fonts[[path, size, style]] ||= Font.new(path, size, style)).tap do |font|
-          if @@loaded_fonts.size > FONT_CACHE_LIMIT
-            @@loaded_fonts.shift
-          end
+        (@loaded_fonts[[path, size, style]] ||= Font.send(:new, path, size, style)).tap do |_font|
+          @loaded_fonts.shift if @loaded_fonts.size > FONT_CACHE_LIMIT
         end
       end
 
@@ -30,33 +38,14 @@ module Ruby2D
         all_paths.map { |path| path.split('/').last.chomp('.ttf').downcase }.uniq.sort
       end
 
-      # Find a font file path from its name
+      # Find a font file path from its name, if it exists in the platforms list of fonts
+      # @return [String] full path if +font_name+ is known
+      # @return [nil] if +font_name+ is unknown
       def path(font_name)
         all_paths.find { |path| path.downcase.include?(font_name) }
       end
 
-      # Get all fonts with full file paths
-      def all_paths
-        # MRuby does not have `Dir` defined
-        if RUBY_ENGINE == 'mruby'
-          fonts = `find #{directory} -name *.ttf`.split("\n")
-        # If MRI and/or non-Bash shell (like cmd.exe)
-        else
-          fonts = Dir["#{directory}/**/*.ttf"]
-        end
-
-        fonts = fonts.reject do |f|
-          f.downcase.include?('bold')    ||
-          f.downcase.include?('italic')  ||
-          f.downcase.include?('oblique') ||
-          f.downcase.include?('narrow')  ||
-          f.downcase.include?('black')
-        end
-
-        fonts.sort_by { |f| f.downcase.chomp '.ttf' }
-      end
-
-      # Get the default font
+      # Get full path to the default font
       def default
         if all.include? 'arial'
           path 'arial'
@@ -65,41 +54,86 @@ module Ruby2D
         end
       end
 
-      # Get the fonts directory for the current platform
-      def directory
-        macos_font_path   = '/Library/Fonts'
-        linux_font_path   = '/usr/share/fonts'
-        windows_font_path = 'C:/Windows/Fonts'
-        openbsd_font_path = '/usr/X11R6/lib/X11/fonts'
+      private
 
-        # If MRI and/or non-Bash shell (like cmd.exe)
-        if Object.const_defined? :RUBY_PLATFORM
-          case RUBY_PLATFORM
-          when /darwin/  # macOS
-            macos_font_path
-          when /linux/
-            linux_font_path
-          when /mingw/
-            windows_font_path
-          when /openbsd/
-            openbsd_font_path
-          end
-        # If MRuby
+      # Get all fonts with full file paths
+      def all_paths
+        # memoize so we only calculate once
+        @all_paths ||= platform_font_paths
+      end
+
+      # Compute and return all platform font file paths, removing variants by style
+      def platform_font_paths
+        fonts = find_os_font_files.reject do |f|
+          f.downcase.include?('bold') ||
+            f.downcase.include?('italic')  ||
+            f.downcase.include?('oblique') ||
+            f.downcase.include?('narrow')  ||
+            f.downcase.include?('black')
+        end
+        fonts.sort_by { |f| f.downcase.chomp '.ttf' }
+      end
+
+      # Return all font files in the platform's font location
+      def find_os_font_files
+        if RUBY_ENGINE == 'mruby'
+          # MRuby does not have `Dir` defined
+          `find #{directory} -name *.ttf`.split("\n")
         else
-          uname = `uname`
-          if uname.include? 'Darwin'  # macOS
-            macos_font_path
-          elsif uname.include? 'Linux'
-            linux_font_path
-          elsif uname.include? 'MINGW'
-            windows_font_path
-          elsif uname.include? 'OpenBSD'
-            openbsd_font_path
-          end
+          # If MRI and/or non-Bash shell (like cmd.exe)
+          Dir["#{directory}/**/*.ttf"]
         end
       end
 
+      # Mapping of OS names to platform-specific font file locations
+      OS_FONT_PATHS = {
+        macos: '/Library/Fonts',
+        linux: '/usr/share/fonts',
+        windows: 'C:/Windows/Fonts',
+        openbsd: '/usr/X11R6/lib/X11/fonts'
+      }.freeze
+
+      # Get the fonts directory for the current platform
+      def directory
+        # If MRI and/or non-Bash shell (like cmd.exe)
+        # memoize so we only calculate once
+        @directory ||= OS_FONT_PATHS[ruby_platform_osname || sys_uname_osname]
+      end
+
+      # Uses RUBY_PLATFORM to identify OS
+      def ruby_platform_osname
+        return unless Object.const_defined? :RUBY_PLATFORM
+
+        case RUBY_PLATFORM
+        when /darwin/ # macOS
+          :macos
+        when /linux/
+          :linux
+        when /mingw/
+          :windows
+        when /openbsd/
+          :openbsd
+        end
+      end
+
+      # Uses uname command to identify OS
+      def sys_uname_osname
+        uname = `uname`
+        if uname.include? 'Darwin' # macOS
+          :macos
+        elsif uname.include? 'Linux'
+          :linux
+        elsif uname.include? 'MINGW'
+          :windows
+        elsif uname.include? 'OpenBSD'
+          :openbsd
+        end
+      end
     end
 
+    # Private constructor, called internally using +Font.send(:new,...)+
+    def initialize(path, size, style = nil)
+      @ttf_font = Font.ext_load(path, size, style.to_s)
+    end
   end
 end


### PR DESCRIPTION
@blacktm, consider this a very preliminary proposal for adding `rubocop.yml` into the repo; the configuration is mostly standard, with tweaks I've added for things that are not as a big a deal. In addition I went through `Font.rb` and cleaned it up as an example that Rubocop doesn't have any complaints about. 

My proposal is to get this initial Rubocop config into the repo and then over time I'd be happy to raise small PRs over time to tweak the variou Ruby classes so they comply. 