### PR TITLE
Add `rake lint` task (does not run automatically)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,13 @@
+AllCops:
+  Exclude:
+    - 'assets/**/*'
+    - 'test/**/*'
+    - 'bin/**/*'
+    - 'build/**/*'
+    - 'ext/**/*'
+    - '**/Rakefile'
+    - '**/*.gemspec'
+
 Naming/MethodParameterName:
   inherit_mode:
     override:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 require_relative 'lib/ruby2d/cli/colorize'
 require_relative 'lib/ruby2d/version'
 
@@ -55,6 +56,12 @@ end
 desc "Update submodules"
 task :update do
   run_cmd "git submodule update --remote"
+end
+
+desc 'Run a Rubocop lint'
+RuboCop::RakeTask.new(:lint) do |t|
+  print_task 'Running Rubocop'
+  t.options = ['--parallel', '--display-cop-names']
 end
 
 desc "Run the RSpec tests"

--- a/ruby2d.gemspec
+++ b/ruby2d.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
   s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'rubocop', '~> 1.30'
 
   s.files = Dir.glob('lib/**/*') +
             Dir.glob('assets/include/**/*') +


### PR DESCRIPTION
@blacktm, this PR 

- adds `lint` task to `Rakefile`
- adds `rubocop` as a dev dependency to the gem spec
- tweaks `.rubocop.yml` to exclude everything except `lib/` 

Requires a `bundle i` to ensure the new dependency is picked up.
