### PR TITLE
Allow String-able file/path names; fix #229

### DIFF
--- a/lib/ruby2d/font.rb
+++ b/lib/ruby2d/font.rb
@@ -20,12 +20,13 @@ module Ruby2D
     class << self
       # Return a font by +path+, +size+ and +style+, loading the font if not already in the cache.
       #
-      # @param [String] path Full path to the font file
-      # @param [Numeric] size Size of font to setup
-      # @param [String] style Font style
+      # @param path [#to_s] Full path to the font file
+      # @param size [Numeric] Size of font to setup
+      # @param style [String] Font style
       #
       # @return [Font]
       def load(path, size, style = nil)
+        path = path.to_s
         raise Error, "Cannot find font file `#{path}`" unless File.exist? path
 
         (@loaded_fonts[[path, size, style]] ||= Font.send(:new, path, size, style)).tap do |_font|
@@ -133,7 +134,7 @@ module Ruby2D
 
     # Private constructor, called internally using +Font.send(:new,...)+
     def initialize(path, size, style = nil)
-      @ttf_font = Font.ext_load(path, size, style.to_s)
+      @ttf_font = Font.ext_load(path.to_s, size, style.to_s)
     end
   end
 end

--- a/lib/ruby2d/image.rb
+++ b/lib/ruby2d/image.rb
@@ -13,7 +13,8 @@ module Ruby2D
     attr_accessor :x, :y, :width, :height, :rotate, :data
 
     # Load an image +path+ and return a Texture, using a pixmap atlas if provided
-    # @param [PixmapAtlas] Optional pixmap atlas to use to manage the image file
+    # @param path [#to_s] The location of the file to load as an image.
+    # @param atlas [PixmapAtlas] Pixmap atlas to use to manage the image file
     # @return [Texture] loaded
     def self.load_image_as_texture(path, atlas:)
       pixmap = if atlas
@@ -25,24 +26,24 @@ module Ruby2D
     end
 
     # Create an Image
-    # @param path The location of the file to load as an image.
-    # @param [Numeric] width The +width+ of image, or default is width from image file
-    # @param [Numeric] height The +height+ of image, or default is height from image file
-    # @param [Numeric] x
-    # @param [Numeric] y
-    # @param [Numeric] z
-    # @param [Numeric] rotate Angle, default is 0
-    # @param [Numeric] color or +colour+ Tint the image when rendering
-    # @param [Numeric] opacity Opacity of the image when rendering
-    # @param [true, false] show If +true+ the image is added to +Window+ automatically.
+    # @param path [#to_s] The location of the file to load as an image.
+    # @param width [Numeric] The +width+ of image, or default is width from image file
+    # @param height [Numeric] The +height+ of image, or default is height from image file
+    # @param x [Numeric]
+    # @param y [Numeric]
+    # @param z [Numeric]
+    # @param rotate [Numeric] Angle, default is 0
+    # @param color [Numeric] (or +colour+) Tint the image when rendering
+    # @param opacity [Numeric] Opacity of the image when rendering
+    # @param show [Boolean] If +true+ the image is added to +Window+ automatically.
     def initialize(path, atlas: nil,
                    width: nil, height: nil, x: 0, y: 0, z: 0,
                    rotate: 0, color: nil, colour: nil,
                    opacity: nil, show: true)
-      @path = path
+      @path = path.to_s
 
       # Consider input pixmap atlas if supplied to load image file
-      @texture = Image.load_image_as_texture path, atlas: atlas
+      @texture = Image.load_image_as_texture @path, atlas: atlas
       @width = width || @texture.width
       @height = height || @texture.height
 

--- a/lib/ruby2d/pixmap.rb
+++ b/lib/ruby2d/pixmap.rb
@@ -23,6 +23,7 @@ module Ruby2D
     attr_reader :width, :height, :path
 
     def initialize(file_path)
+      file_path = file_path.to_s
       raise UnknownImageFileError, file_path unless File.exist? file_path
 
       ext_load_pixmap(file_path)

--- a/lib/ruby2d/sprite.rb
+++ b/lib/ruby2d/sprite.rb
@@ -9,11 +9,11 @@ module Ruby2D
 
     def initialize(path, opts = {})
       # Sprite image file path
-      @path = path
+      @path = path.to_s
 
       # Initialize the sprite texture
       # Consider input pixmap atlas if supplied to load image file
-      @texture = Image.load_image_as_texture path, atlas: opts[:atlas]
+      @texture = Image.load_image_as_texture @path, atlas: opts[:atlas]
       @img_width = @texture.width
       @img_height = @texture.height
 

--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -7,11 +7,11 @@ module Ruby2D
     include Renderable
 
     def initialize(path, opts = {})
-      @path = path
+      @path = path.to_s
 
       # Initialize the tileset texture
       # Consider input pixmap atlas if supplied to load image file
-      @texture = Image.load_image_as_texture path, atlas: opts[:atlas]
+      @texture = Image.load_image_as_texture @path, atlas: opts[:atlas]
       @width = opts[:width] || @texture.width
       @height = opts[:height] || @texture.height
       @z = opts[:z] || 0

--- a/test/support/image_like_helpers.rb
+++ b/test/support/image_like_helpers.rb
@@ -1,4 +1,5 @@
 require 'ruby2d'
+require 'pathname'
 
 # Image and Sprite are very similar. This helper defines  tests
 # so that specs for objects that are "image like" can share tests.
@@ -51,6 +52,17 @@ shared_examples 'image-loading tests' do
     let(:path) { not_found_path }
     it 'fails' do
       expect { subject }.to raise_error(Ruby2D::Error)
+    end
+  end
+
+  context 'using pathname' do
+    let(:path) { Pathname.new(test_media('image.png')) }
+    it 'converts path to string' do
+      expect(subject.path.is_a?(String)).to be true
+    end
+
+    it 'succeeds' do
+      expect(subject.path).to end_with test_media('image.png')
     end
   end
 end

--- a/test/text_spec.rb
+++ b/test/text_spec.rb
@@ -2,6 +2,15 @@ require 'ruby2d'
 
 RSpec.describe Ruby2D::Text do
   describe '#new' do
+    context 'using pathname' do
+      it 'succeeds' do
+        expect do
+          Text.new('hello',
+                   font: Pathname.new("#{Ruby2D.test_media}/bitstream_vera/vera.ttf"))
+        end.not_to raise_error
+      end
+    end
+
     it "raises exception if font file doesn't exist" do
       expect { Text.new('hello', font: 'bad_font.ttf') }.to raise_error(Ruby2D::Error)
     end
@@ -68,7 +77,7 @@ RSpec.describe Ruby2D::Text do
 
       txt.size = 20
       expect(txt.width).to be > original_width
-      expect(txt.height).to be > original_width
+      expect(txt.height).to be > original_height
     end
   end
 


### PR DESCRIPTION
Closes #229

* All objects that receive a file path use `#to_s` to get a string from the input
* Added test using `Pathname.new` 
* Fixed a typo in `text.spec` test (unrelated)