### PR TITLE
Delint Sprite and related internal classes

### DIFF
--- a/lib/ruby2d/texture.rb
+++ b/lib/ruby2d/texture.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 # Ruby2D::Texture
 
 module Ruby2D
+  # This internal class is used to hold raw pixel data which in turn is used to
+  # render textures via openGL rendering code.
   class Texture
     attr_reader :width, :height, :texture_id
 
@@ -12,7 +16,7 @@ module Ruby2D
     end
 
     def draw(coordinates, texture_coordinates, color)
-      if @texture_id == 0
+      if @texture_id.zero?
         @texture_id = ext_create(@pixel_data, @width, @height)
         @pixel_data = nil
       end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # Ruby2D::Vertices
 
-# This class generates a vertices array which are passed to the openGL rendering code.
-# The vertices array is split up into 4 groups (1 - top left, 2 - top right, 3 - bottom right, 4 - bottom left)
-# This class is responsible for transforming textures, it can scale / crop / rotate and flip textures
-
 module Ruby2D
+  # This internal class generates a vertices array which are passed to the openGL rendering code.
+  # The vertices array is split up into 4 groups (1 - top left, 2 - top right, 3 - bottom right, 4 - bottom left)
+  # This class is responsible for transforming textures, it can scale / crop / rotate and flip textures
   class Vertices
     def initialize(x, y, width, height, rotate, crop: nil, flip: nil)
       @flip = flip
@@ -12,53 +13,34 @@ module Ruby2D
       @y = y
       @width = width.to_f
       @height = height.to_f
-
-      if @flip == :horizontal || @flip == :both
-        @x = @x + @width
-        @width = -@width
-      end
-
-      if @flip == :vertical || @flip == :both
-        @y = y + @height
-        @height = -@height
-      end
-
       @rotate = rotate
       @rx = @x + (@width / 2.0)
       @ry = @y + (@height / 2.0)
       @crop = crop
+      @coordinates = nil
+      @texture_coordinates = nil
+      _apply_flip
     end
 
     def coordinates
-      if @rotate == 0
-        x1, y1 = @x,          @y;           # Top left
-        x2, y2 = @x + @width, @y;           # Top right
-        x3, y3 = @x + @width, @y + @height; # Bottom right
-        x4, y4 = @x,          @y + @height; # Bottom left
-      else
-        x1, y1 = rotate(@x,          @y);           # Top left
-        x2, y2 = rotate(@x + @width, @y);           # Top right
-        x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
-        x4, y4 = rotate(@x,          @y + @height); # Bottom left
-      end
-
-      [ x1, y1, x2, y2, x3, y3, x4, y4 ]
+      @coordinates ||= if @rotate.zero?
+                         _unrotated_coordinates
+                       else
+                         _calculate_coordinates
+                       end
     end
 
     def texture_coordinates
-      if @crop.nil?
-        tx1 = 0.0; ty1 = 0.0 # Top left
-        tx2 = 1.0; ty2 = 0.0 # Top right
-        tx3 = 1.0; ty3 = 1.0 # Bottom right
-        tx4 = 0.0; ty4 = 1.0 # Bottom left
-      else
-        tx1 = @crop[:x] / @crop[:image_width].to_f; ty1 = @crop[:y] / @crop[:image_height].to_f # Top left
-        tx2 = tx1 + (@crop[:width] / @crop[:image_width].to_f); ty2 = ty1                       # Top right
-        tx3 = tx2; ty3 = ty1 + (@crop[:height] / @crop[:image_height].to_f)                     # Botttom right
-        tx4 = tx1; ty4 = ty3                                                                    # Bottom left
-      end
-
-      [ tx1, ty1, tx2, ty2, tx3, ty3, tx4, ty4 ]
+      @texture_coordinates ||= if @crop.nil?
+                                 [
+                                   0.0, 0.0, # top left
+                                   1.0, 0.0,   # top right
+                                   1.0, 1.0,   # bottom right
+                                   0.0, 1.0    # bottom left
+                                 ]
+                               else
+                                 _calculate_texture_coordinates
+                               end
     end
 
     private
@@ -76,14 +58,66 @@ module Ruby2D
       y -= @ry
 
       # Rotate point
-      xnew = x * ca - y * sa;
-      ynew = x * sa + y * ca;
+      xnew = x * ca - y * sa
+      ynew = x * sa + y * ca
 
       # Translate point back
-      x = xnew + @rx;
-      y = ynew + @ry;
+      x = xnew + @rx
+      y = ynew + @ry
 
       [x, y]
+    end
+
+    def _unrotated_coordinates
+      x1 = @x
+      y1 = @y;           # Top left
+      x2 = @x + @width
+      y2 = @y;           # Top right
+      x3 = @x + @width
+      y3 = @y + @height; # Bottom right
+      x4 = @x
+      y4 = @y + @height; # Bottom left
+      [x1, y1, x2, y2, x3, y3, x4, y4]
+    end
+
+    def _calculate_coordinates
+      x1, y1 = rotate(@x,          @y);           # Top left
+      x2, y2 = rotate(@x + @width, @y);           # Top right
+      x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
+      x4, y4 = rotate(@x,          @y + @height); # Bottom left
+      [x1, y1, x2, y2, x3, y3, x4, y4]
+    end
+
+    def _calculate_texture_coordinates
+      img_width = @crop[:image_width].to_f
+      img_height = @crop[:image_height].to_f
+
+      # Top left
+      tx1 = @crop[:x] / img_width
+      ty1 = @crop[:y] / img_height
+      # Top right
+      tx2 = tx1 + (@crop[:width] / img_width)
+      ty2 = ty1
+      # Botttom right
+      tx3 = tx2
+      ty3 = ty1 + (@crop[:height] / img_height)
+      # Bottom left
+      # tx4 = tx1
+      # ty4 = ty3
+
+      [tx1, ty1, tx2, ty2, tx3, ty3, tx1, ty3]
+    end
+
+    def _apply_flip
+      if @flip == :horizontal || @flip == :both
+        @x += @width
+        @width = -@width
+      end
+
+      return unless @flip == :vertical || @flip == :both
+
+      @y = y + @height
+      @height = -@height
     end
   end
 end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -19,7 +19,7 @@ module Ruby2D
       @crop = crop
       @coordinates = nil
       @texture_coordinates = nil
-      _apply_flip
+      _apply_flip unless @flip.nil?
     end
 
     def coordinates
@@ -30,14 +30,16 @@ module Ruby2D
                        end
     end
 
+    TEX_UNCROPPED_COORDS = [
+      0.0, 0.0, # top left
+      1.0, 0.0,   # top right
+      1.0, 1.0,   # bottom right
+      0.0, 1.0    # bottom left
+    ].freeze
+
     def texture_coordinates
       @texture_coordinates ||= if @crop.nil?
-                                 [
-                                   0.0, 0.0, # top left
-                                   1.0, 0.0,   # top right
-                                   1.0, 1.0,   # bottom right
-                                   0.0, 1.0    # bottom left
-                                 ]
+                                 TEX_UNCROPPED_COORDS
                                else
                                  _calculate_texture_coordinates
                                end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -118,7 +118,7 @@ module Ruby2D
 
       return unless @flip == :vertical || @flip == :both
 
-      @y = y + @height
+      @y += @height
       @height = -@height
     end
   end


### PR DESCRIPTION
@blacktm, here's a delinting PR focused on the following classes. They should all behave as before.

* `Sprite` - mainly re-arranging and tweaking to simplify the methods
* `Vertices` - mainly re-arranging, but along the way memoized the `coordinates` and `texture_coordinates` methods to that repeated use of an instance will not recalculate coordinates; since the class appears to be immutable, this should have no side-effects.
* `Texture` - very minor tweak to use `.zero?` instead of a comparison.
