### PR TITLE
Delint and optimise tileset

### DIFF
--- a/lib/ruby2d/texture.rb
+++ b/lib/ruby2d/texture.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 # Ruby2D::Texture
 
 module Ruby2D
+  # This internal class is used to hold raw pixel data which in turn is used to
+  # render textures via openGL rendering code.
   class Texture
     attr_reader :width, :height, :texture_id
 
@@ -12,7 +16,7 @@ module Ruby2D
     end
 
     def draw(coordinates, texture_coordinates, color)
-      if @texture_id == 0
+      if @texture_id.zero?
         @texture_id = ext_create(@pixel_data, @width, @height)
         @pixel_data = nil
       end

--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -1,51 +1,95 @@
+# frozen_string_literal: true
+
 # Ruby2D::Tileset
 
 module Ruby2D
+  # Tilesets are images containing multiple unique tiles. These tiles can be drawn to the
+  # screen multiple times in interesting combinations to produce things like backgrounds
+  # or draw larger objects.
   class Tileset
     DEFAULT_COLOR = Color.new([1.0, 1.0, 1.0, 1.0])
 
     include Renderable
 
-    def initialize(path, opts = {})
+    # Setup a Tileset with an image.
+    # @param path [#to_s] The location of the file to load as an image.
+    # @param width [Numeric] The +width+ of image, or default is width from image file
+    # @param height [Numeric] The +height+ of image, or default is height from image file
+    # @param z [Numeric]
+    # @param padding [Numeric]
+    # @param spacing [Numeric]
+    # @param tile_width [Numeric] Width of each tile in pixels
+    # @param tile_height [Numeric] Height of each tile in pixels
+    # @param scale [Numeric] Default is 1
+    # @param show [Boolean] If +true+ the image is added to +Window+ automatically.
+    def initialize(path, tile_width: 32, tile_height: 32, atlas: nil,
+                   width: nil, height: nil, z: 0,
+                   padding: 0, spacing: 0,
+                   scale: 1, show: true)
       @path = path.to_s
 
       # Initialize the tileset texture
       # Consider input pixmap atlas if supplied to load image file
-      @texture = Image.load_image_as_texture @path, atlas: opts[:atlas]
-      @width = opts[:width] || @texture.width
-      @height = opts[:height] || @texture.height
-      @z = opts[:z] || 0
+      @texture = Image.load_image_as_texture @path, atlas: atlas
+      @width = width || @texture.width
+      @height = height || @texture.height
+      @z = z
 
       @tiles = []
-      @defined_tiles = {}
-      @padding = opts[:padding] || 0
-      @spacing = opts[:spacing] || 0
-      @tile_width = opts[:tile_width]
-      @tile_height = opts[:tile_height]
-      @scale = opts[:scale] || 1
+      @tile_definitions = {}
+      @padding = padding
+      @spacing = spacing
+      @tile_width = tile_width
+      @tile_height = tile_height
+      @scale = scale
 
-      unless opts[:show] == false then add end
+      _calculate_scaled_sizes
+
+      add if show
     end
 
+    # Define and name a tile in the tileset image by its position. The actual tiles
+    # to be drawn are declared using {#set_tile}
+    #
+    # @param name [String] A unique name for the tile in the tileset
+    # @param x [Numeric] Column position of the tile
+    # @param y [Numeric] Row position of the tile
+    # @param rotate [Numeric] Angle of the title when drawn, default is 0
+    # @param flip [nil, :vertical, :horizontal, :both] Direction to flip the tile if desired
     def define_tile(name, x, y, rotate: 0, flip: nil)
-      @defined_tiles[name] = { x: x, y: y , rotate: rotate, flip: flip }
+      @tile_definitions[name] = { x: x, y: y, rotate: rotate, flip: flip }
     end
 
+    # Select and "stamp" or set/place a tile to be drawn
+    # @param name [String] The name of the tile defined using +#define_tile+
+    # @param coordinates [Array<{"x", "y" => Numeric}>] one or more +{x:, y:}+ coordinates to draw the tile
     def set_tile(name, coordinates)
-      tile = @defined_tiles.fetch(name)
+      tile_def = @tile_definitions.fetch(name)
+      crop = _calculate_tile_crop(tile_def)
 
       coordinates.each do |coordinate|
+        # Use Vertices object for tile placement so we can use them
+        # directly when drawing the textures instead of making them for
+        # every tile placement for each draw, and re-use the crop from
+        # the tile definition
+        vertices = Vertices.new(
+          coordinate.fetch(:x), coordinate.fetch(:y),
+          @scaled_tile_width, @scaled_tile_height,
+          tile_def.fetch(:rotate),
+          crop: crop,
+          flip: tile_def.fetch(:flip)
+        )
+        # Remember the referenced tile for if we ever want to recalculate
+        # them all due to change to scale etc (currently n/a since
+        # scale is immutable)
         @tiles.push({
-          tile_x: tile.fetch(:x), 
-          tile_y: tile.fetch(:y), 
-          tile_rotate: tile.fetch(:rotate),
-          tile_flip: tile.fetch(:flip),
-          x: coordinate.fetch(:x),
-          y: coordinate.fetch(:y)
-        })
+                      tile_def: tile_def,
+                      vertices: vertices
+                    })
       end
     end
 
+    # Removes all stamped tiles so nothing is drawn.
     def clear_tiles
       @tiles = []
     end
@@ -58,28 +102,36 @@ module Ruby2D
 
     private
 
+    def _calculate_tile_crop(tile_def)
+      # Re-use if crop has already been calculated
+      return tile_def.fetch(:scaled_crop) if tile_def.key?(:scaled_crop)
+
+      # Calculate the crop for each tile definition the first time a tile
+      # is placed/set, so that we can later re-use when placing tiles,
+      # avoiding creating the crop object for every placement.
+      tile_def[:scaled_crop] = {
+        x: @scaled_padding + (tile_def.fetch(:x) * (@scaled_spacing + @scaled_tile_width)),
+        y: @scaled_padding + (tile_def.fetch(:y) * (@scaled_spacing + @scaled_tile_height)),
+        width: @scaled_tile_width,
+        height: @scaled_tile_height,
+        image_width: @scaled_width,
+        image_height: @scaled_height
+      }.freeze
+    end
+
+    def _calculate_scaled_sizes
+      @scaled_padding = @padding * @scale
+      @scaled_spacing = @spacing * @scale
+      @scaled_tile_width = @tile_width * @scale
+      @scaled_tile_height = @tile_height * @scale
+      @scaled_width = @width * @scale
+      @scaled_height = @height * @scale
+    end
+
     def render
-      scaled_padding = @padding * @scale
-      scaled_spacing = @spacing * @scale
-      scaled_tile_width = @tile_width * @scale
-      scaled_tile_height = @tile_height * @scale
-      scaled_width = @width * @scale
-      scaled_height = @height * @scale
-
-      @tiles.each do |tile|
-        crop = {
-          x: scaled_padding + (tile.fetch(:tile_x) * (scaled_spacing + scaled_tile_width)),
-          y: scaled_padding + (tile.fetch(:tile_y) * (scaled_spacing + scaled_tile_height)),
-          width: scaled_tile_width,
-          height: scaled_tile_height,
-          image_width: scaled_width,
-          image_height: scaled_height,
-        }
-
-        color = defined?(@color) ? @color : DEFAULT_COLOR
-
-        vertices = Vertices.new(tile.fetch(:x), tile.fetch(:y), scaled_tile_width, scaled_tile_height, tile.fetch(:tile_rotate), crop: crop, flip: tile.fetch(:tile_flip))
-
+      color = defined?(@color) ? @color : DEFAULT_COLOR
+      @tiles.each do |placement|
+        vertices = placement.fetch(:vertices)
         @texture.draw(
           vertices.coordinates, vertices.texture_coordinates, color
         )

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # Ruby2D::Vertices
 
-# This class generates a vertices array which are passed to the openGL rendering code.
-# The vertices array is split up into 4 groups (1 - top left, 2 - top right, 3 - bottom right, 4 - bottom left)
-# This class is responsible for transforming textures, it can scale / crop / rotate and flip textures
-
 module Ruby2D
+  # This internal class generates a vertices array which are passed to the openGL rendering code.
+  # The vertices array is split up into 4 groups (1 - top left, 2 - top right, 3 - bottom right, 4 - bottom left)
+  # This class is responsible for transforming textures, it can scale / crop / rotate and flip textures
   class Vertices
     def initialize(x, y, width, height, rotate, crop: nil, flip: nil)
       @flip = flip
@@ -12,53 +13,34 @@ module Ruby2D
       @y = y
       @width = width.to_f
       @height = height.to_f
-
-      if @flip == :horizontal || @flip == :both
-        @x = @x + @width
-        @width = -@width
-      end
-
-      if @flip == :vertical || @flip == :both
-        @y = y + @height
-        @height = -@height
-      end
-
       @rotate = rotate
       @rx = @x + (@width / 2.0)
       @ry = @y + (@height / 2.0)
       @crop = crop
+      @coordinates = nil
+      @texture_coordinates = nil
+      _apply_flip
     end
 
     def coordinates
-      if @rotate == 0
-        x1, y1 = @x,          @y;           # Top left
-        x2, y2 = @x + @width, @y;           # Top right
-        x3, y3 = @x + @width, @y + @height; # Bottom right
-        x4, y4 = @x,          @y + @height; # Bottom left
-      else
-        x1, y1 = rotate(@x,          @y);           # Top left
-        x2, y2 = rotate(@x + @width, @y);           # Top right
-        x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
-        x4, y4 = rotate(@x,          @y + @height); # Bottom left
-      end
-
-      [ x1, y1, x2, y2, x3, y3, x4, y4 ]
+      @coordinates ||= if @rotate.zero?
+                         _unrotated_coordinates
+                       else
+                         _calculate_coordinates
+                       end
     end
 
     def texture_coordinates
-      if @crop.nil?
-        tx1 = 0.0; ty1 = 0.0 # Top left
-        tx2 = 1.0; ty2 = 0.0 # Top right
-        tx3 = 1.0; ty3 = 1.0 # Bottom right
-        tx4 = 0.0; ty4 = 1.0 # Bottom left
-      else
-        tx1 = @crop[:x] / @crop[:image_width].to_f; ty1 = @crop[:y] / @crop[:image_height].to_f # Top left
-        tx2 = tx1 + (@crop[:width] / @crop[:image_width].to_f); ty2 = ty1                       # Top right
-        tx3 = tx2; ty3 = ty1 + (@crop[:height] / @crop[:image_height].to_f)                     # Botttom right
-        tx4 = tx1; ty4 = ty3                                                                    # Bottom left
-      end
-
-      [ tx1, ty1, tx2, ty2, tx3, ty3, tx4, ty4 ]
+      @texture_coordinates ||= if @crop.nil?
+                                 [
+                                   0.0, 0.0, # top left
+                                   1.0, 0.0,   # top right
+                                   1.0, 1.0,   # bottom right
+                                   0.0, 1.0    # bottom left
+                                 ]
+                               else
+                                 _calculate_texture_coordinates
+                               end
     end
 
     private
@@ -76,14 +58,66 @@ module Ruby2D
       y -= @ry
 
       # Rotate point
-      xnew = x * ca - y * sa;
-      ynew = x * sa + y * ca;
+      xnew = x * ca - y * sa
+      ynew = x * sa + y * ca
 
       # Translate point back
-      x = xnew + @rx;
-      y = ynew + @ry;
+      x = xnew + @rx
+      y = ynew + @ry
 
       [x, y]
+    end
+
+    def _unrotated_coordinates
+      x1 = @x
+      y1 = @y;           # Top left
+      x2 = @x + @width
+      y2 = @y;           # Top right
+      x3 = @x + @width
+      y3 = @y + @height; # Bottom right
+      x4 = @x
+      y4 = @y + @height; # Bottom left
+      [x1, y1, x2, y2, x3, y3, x4, y4]
+    end
+
+    def _calculate_coordinates
+      x1, y1 = rotate(@x,          @y);           # Top left
+      x2, y2 = rotate(@x + @width, @y);           # Top right
+      x3, y3 = rotate(@x + @width, @y + @height); # Bottom right
+      x4, y4 = rotate(@x,          @y + @height); # Bottom left
+      [x1, y1, x2, y2, x3, y3, x4, y4]
+    end
+
+    def _calculate_texture_coordinates
+      img_width = @crop[:image_width].to_f
+      img_height = @crop[:image_height].to_f
+
+      # Top left
+      tx1 = @crop[:x] / img_width
+      ty1 = @crop[:y] / img_height
+      # Top right
+      tx2 = tx1 + (@crop[:width] / img_width)
+      ty2 = ty1
+      # Botttom right
+      tx3 = tx2
+      ty3 = ty1 + (@crop[:height] / img_height)
+      # Bottom left
+      # tx4 = tx1
+      # ty4 = ty3
+
+      [tx1, ty1, tx2, ty2, tx3, ty3, tx1, ty3]
+    end
+
+    def _apply_flip
+      if @flip == :horizontal || @flip == :both
+        @x += @width
+        @width = -@width
+      end
+
+      return unless @flip == :vertical || @flip == :both
+
+      @y = y + @height
+      @height = -@height
     end
   end
 end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -19,7 +19,7 @@ module Ruby2D
       @crop = crop
       @coordinates = nil
       @texture_coordinates = nil
-      _apply_flip
+      _apply_flip unless @flip.nil?
     end
 
     def coordinates
@@ -30,14 +30,16 @@ module Ruby2D
                        end
     end
 
+    TEX_UNCROPPED_COORDS = [
+      0.0, 0.0, # top left
+      1.0, 0.0,   # top right
+      1.0, 1.0,   # bottom right
+      0.0, 1.0    # bottom left
+    ].freeze
+
     def texture_coordinates
       @texture_coordinates ||= if @crop.nil?
-                                 [
-                                   0.0, 0.0, # top left
-                                   1.0, 0.0,   # top right
-                                   1.0, 1.0,   # bottom right
-                                   0.0, 1.0    # bottom left
-                                 ]
+                                 TEX_UNCROPPED_COORDS
                                else
                                  _calculate_texture_coordinates
                                end

--- a/lib/ruby2d/vertices.rb
+++ b/lib/ruby2d/vertices.rb
@@ -118,7 +118,7 @@ module Ruby2D
 
       return unless @flip == :vertical || @flip == :both
 
-      @y = y + @height
+      @y += @height
       @height = -@height
     end
   end


### PR DESCRIPTION
> This PR depends on #253 for improvements made to `Vertices`.

@blacktm, here's a PR with improvements to `Tileset` as follows:

* Delinting, including cleaning up constructor parameter definition and adding API docs
* Optimized the `#render` by creating a `Vertices` object per stamped tile when `#set_tile` is called.
  * Previously, each call to `#render` created many objects: a `crop` and `Vertices` per tile placement.
  * Now, when `#set_tile` is called, 
    * a `crop` is created once per _used_ tile definition, and 
    * a `Vertices` object is created per tile placement coordinate
  * As a result the call to each `#render` creates zero new objects, reducing GC when using tilesets and improving performance.

To verify no functionality was impacted, I compared a screenshot of `rake test tileset` before and after the changes to ensure the rendering was identical.

### FYI and future scope

The `Tileset` as defined is currently immobile; i.e. the tile placement is absolute per tile and any animation would require clearing and calling `#set_tile` again with new coordinates. An improvement to do later is to place the tileset absolutely and set each tile's coordinate relatively so that we could move the tileset via it's position. 
