### PR TITLE
Delint triangle and auto mixin

### DIFF
--- a/lib/ruby2d.rb
+++ b/lib/ruby2d.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Ruby2D module and native extension loader, adds DSL
 
 unless RUBY_ENGINE == 'mruby'
@@ -27,10 +29,11 @@ unless RUBY_ENGINE == 'mruby'
   require 'ruby2d/music'
   require 'ruby2d/texture'
   require 'ruby2d/vertices'
-  require 'ruby2d/ruby2d'  # load native extension
+  require 'ruby2d/ruby2d' # load native extension
 end
 
-
+# Create 2D applications, games, and visualizations with ease. Just a few lines of code is enough to get started.
+# Visit https://www.ruby2d.com for more information.
 module Ruby2D
   def self.gem_dir
     # mruby doesn't define `Gem`
@@ -50,6 +53,14 @@ module Ruby2D
   end
 end
 
+unless ENV.key? 'DISABLE_RUBY2D_AUTO_MIXIN'
+  # Mixin by default.
+  # Allow apps to avoid that via environment variable
 
-include Ruby2D
-extend  Ruby2D::DSL
+  # --- start lint exception
+  # rubocop:disable Style/MixinUsage
+  include Ruby2D
+  extend Ruby2D::DSL
+  # rubocop:enable Style/MixinUsage
+  # --- end lint exception
+end

--- a/lib/ruby2d/quad.rb
+++ b/lib/ruby2d/quad.rb
@@ -12,10 +12,10 @@ module Ruby2D
     # x2,y2 == top right
     # x3,y3 == bottom right
     # x4,y4 == bottom left
-    attr_accessor :x1, :y1, :c1,
-                  :x2, :y2, :c2,
-                  :x3, :y3, :c3,
-                  :x4, :y4, :c4
+    attr_accessor :x1, :y1,
+                  :x2, :y2,
+                  :x3, :y3,
+                  :x4, :y4
 
     # Create an quadrilateral
     # @param [Numeric] x1
@@ -86,7 +86,8 @@ module Ruby2D
     # @param [Numeric] y3
     # @param [Numeric] x4
     # @param [Numeric] y4
-    # @param [Array] colors An array of 4 arrays of colour components.
+    # @param color [Array<Array<float,float,float,float>>] An array of 4 array of colour components
+    #                                       (e.g. [[1.0, 0, 0, 1.0], ...])
     def self.draw(x1:, y1:, x2:, y2:, x3:, y3:, x4:, y4:, color:)
       Window.render_ready_check
       ext_draw([

--- a/lib/ruby2d/triangle.rb
+++ b/lib/ruby2d/triangle.rb
@@ -1,29 +1,57 @@
+# frozen_string_literal: true
+
 # Ruby2D::Triangle
 
 module Ruby2D
+  # A triangle
   class Triangle
     include Renderable
 
-    attr_accessor :x1, :y1, :c1,
-                  :x2, :y2, :c2,
-                  :x3, :y3, :c3
+    attr_accessor :x1, :y1,
+                  :x2, :y2,
+                  :x3, :y3
+    attr_reader :color
 
-    def initialize(opts= {})
-      @x1 = opts[:x1] || 50
-      @y1 = opts[:y1] || 0
-      @x2 = opts[:x2] || 100
-      @y2 = opts[:y2] || 100
-      @x3 = opts[:x3] || 0
-      @y3 = opts[:y3] || 100
-      @z  = opts[:z]  || 0
-      self.color = opts[:color] || 'white'
-      self.color.opacity = opts[:opacity] if opts[:opacity]
+    # Create a triangle
+    # @param x1 [Numeric]
+    # @param y1 [Numeric]
+    # @param x2 [Numeric]
+    # @param y2 [Numeric]
+    # @param x3 [Numeric]
+    # @param y3 [Numeric]
+    # @param z [Numeric]
+    # @param color [String, Array] A single colour or an array of exactly 3 colours
+    # @param opacity [Numeric] Opacity of the image when rendering
+    # @raise [ArgumentError] if an array of colours does not have 3 entries
+    def initialize(x1: 50, y1: 0, x2: 100, y2: 100, x3: 0, y3: 100,
+                   z: 0, color: 'white', colour: nil, opacity: nil)
+      @x1 = x1
+      @y1 = y1
+      @x2 = x2
+      @y2 = y2
+      @x3 = x3
+      @y3 = y3
+      @z  = z
+      self.color = color || colour
+      self.color.opacity = opacity if opacity
       add
     end
 
-    def color=(c)
-      @color = Color.set(c)
-      update_color(@color)
+    # Change the colour of the line
+    # @param [String, Array] color A single colour or an array of exactly 3 colours
+    # @raise [ArgumentError] if an array of colours does not have 3 entries
+    def color=(color)
+      # convert to Color or Color::Set
+      color = Color.set(color)
+
+      # require 3 colours if multiple colours provided
+      if color.is_a?(Color::Set) && color.length != 3
+        raise ArgumentError,
+              "`#{self.class}` requires 3 colors, one for each vertex. #{color.length} were given."
+      end
+
+      @color = color # converted above
+      invalidate_color_components
     end
 
     # A point is inside a triangle if the area of 3 triangles, constructed from
@@ -38,45 +66,66 @@ module Ruby2D
       questioned_area <= self_area
     end
 
-    def self.draw(opts = {})
+    # Draw a triangle
+    # @param x1 [Numeric]
+    # @param y1 [Numeric]
+    # @param x2 [Numeric]
+    # @param y2 [Numeric]
+    # @param x3 [Numeric]
+    # @param y3 [Numeric]
+    # @param z [Numeric]
+    # @param color [Array<Array<float,float,float,float>>] An array of 3 arrays of colour components
+    #                                  (e.g. [[1.0, 0, 0, 1.0], ...])
+    def self.draw(x1:, y1:, x2:, y2:, x3:, y3:, color:)
       Window.render_ready_check
-
       ext_draw([
-        opts[:x1], opts[:y1], opts[:color][0][0], opts[:color][0][1], opts[:color][0][2], opts[:color][0][3],
-        opts[:x2], opts[:y2], opts[:color][1][0], opts[:color][1][1], opts[:color][1][2], opts[:color][1][3],
-        opts[:x3], opts[:y3], opts[:color][2][0], opts[:color][2][1], opts[:color][2][2], opts[:color][2][3]
-      ])
+                 x1, y1, *color[0], # splat the colour components
+                 x2, y2, *color[1],
+                 x3, y3, *color[2]
+               ])
     end
 
     private
 
     def render
+      color_comp_arrays = color_components
       self.class.ext_draw([
-        @x1, @y1, @c1.r, @c1.g, @c1.b, @c1.a,
-        @x2, @y2, @c2.r, @c2.g, @c2.b, @c2.a,
-        @x3, @y3, @c3.r, @c3.g, @c3.b, @c3.a
-      ])
+                            @x1, @y1, *color_comp_arrays[0], # splat the colour components
+                            @x2, @y2, *color_comp_arrays[1],
+                            @x3, @y3, *color_comp_arrays[2]
+                          ])
     end
 
     def triangle_area(x1, y1, x2, y2, x3, y3)
-      (x1*y2 + x2*y3 + x3*y1 - x3*y2 - x1*y3 - x2*y1).abs / 2
+      (x1 * y2 + x2 * y3 + x3 * y1 - x3 * y2 - x1 * y3 - x2 * y1).abs / 2
     end
 
-    def update_color(c)
-      if c.is_a? Color::Set
-        if c.length == 3
-          @c1 = c[0]
-          @c2 = c[1]
-          @c3 = c[2]
-        else
-          raise ArgumentError, "`#{self.class}` requires 3 colors, one for each vertex. #{c.length} were given."
-        end
-      else
-        @c1 = c
-        @c2 = c
-        @c3 = c
-      end
+    # Return colours as a memoized array of 3 x colour component arrays
+    def color_components
+      check_if_opacity_changed
+      @color_components ||= if @color.is_a? Color::Set
+                              # Extract colour component arrays; see +def color=+ where colour set
+                              # size is enforced
+                              [
+                                @color[0].to_a, @color[1].to_a, @color[2].to_a
+                              ]
+                            else
+                              # All vertex colours are the same
+                              c_a = @color.to_a
+                              [
+                                c_a, c_a, c_a
+                              ]
+                            end
     end
 
+    # Invalidate memoized colour components if opacity has been changed via +color=+
+    def check_if_opacity_changed
+      @color_components = nil if @color_components && @color_components.first[3] != @color.opacity
+    end
+
+    # Invalidate the memoized colour components. Called when Line's colour is changed
+    def invalidate_color_components
+      @color_components = nil
+    end
   end
 end

--- a/test/without_auto_mixin.rb
+++ b/test/without_auto_mixin.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'ruby2d'
+
+#
+# Test Ruby2D without global mixin
+# Run this test as follows:
+# ```sh
+# DISABLE_RUBY2D_AUTO_MIXIN=true rake test without_auto_mixin
+# ```
+module MyRuby2D
+  include Ruby2D
+
+  Window.set title: 'Hello Triangle'
+
+  Triangle.new(
+    x1: 320, y1:  50,
+    x2: 540, y2: 430,
+    x3: 100, y3: 430,
+    color: %w[red green blue]
+  )
+
+  Window.show
+end


### PR DESCRIPTION
@blacktm, this PR has two changes:

1. Delint `Triangle` which finishes all the cleanup of the `lib/ruby2d/` objects (except `cli/` which I will tackle separately.)
  * and a tweak to `Quad` which I missed earlier.
2. Adds support for an environment variable `DISABLE_RUBY2D_AUTO_MIXIN` which can be used to choose to prevent the automatic mixin of `Ruby2D::` into the global namespace.
    * See #173 for the issue that describes the concern with namespace pollution. 
    * I still think the default is OK since Ruby2D targets educational users and this really simplifies getting started
    * However the env var allows the Rubyists to choose to forego this convenience.
    * I added `test/without_auto_mixin.rb` as a simple example of how this could be used. Try running it like so:

```sh
DISABLE_RUBY2D_AUTO_MIXIN=true rake test without_auto_mixin
```
