### PR TITLE
Support one-time initializer for Window

### DIFF
--- a/lib/ruby2d/dsl.rb
+++ b/lib/ruby2d/dsl.rb
@@ -3,10 +3,16 @@
 module Ruby2D
   # Ruby2D::DSL
   module DSL
-    @window = Ruby2D::Window.new
+    @window = nil
+
+    # Call this with a block to perform one-time initialization using
+    # the current window. E.g. `initialize_once do |win| ... end`
+    def initialize_once(&block)
+      DSL.window.run_once(&block) if block
+    end
 
     def self.window
-      @window
+      @window ||= Ruby2D::Window.new
     end
 
     def self.window=(window)

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -60,7 +60,7 @@ module Ruby2D
     # @raise ArgumentError if called more than once, or if block already supplied when initializing Window.
     def run_once
       return unless block_given?
-      raise(ArgumentError, 'Already initialized') if @run_once
+      return if @run_once
 
       @run_once = true
       yield self

--- a/lib/ruby2d/window.rb
+++ b/lib/ruby2d/window.rb
@@ -15,13 +15,14 @@ module Ruby2D
     ControllerButtonEvent = Struct.new(:which, :button)
 
     #
-    # Create a Window
+    # Create a Window, and after any parameters optionally supply a do block for one-time initialization after the window
+    # is created. E.g `Window.new ... do |win| ... end`
     # @param title [String] Title for the window
     # @param width [Numeric] In pixels
     # @param height [Numeric] in pixels
     # @param fps_cap [Numeric] Over-ride the default (60fps) frames-per-second
     # @param vsync [Boolean] Enabled by default, use this to override it (Not recommended)
-    def initialize(title: 'Ruby 2D', width: 640, height: 480, fps_cap: 60, vsync: true)
+    def initialize(title: 'Ruby 2D', width: 640, height: 480, fps_cap: 60, vsync: true, &block)
       # Title of the window
       @title = title
 
@@ -46,6 +47,23 @@ module Ruby2D
       _init_event_stores
       _init_event_registrations
       _init_procs_dsl_console
+
+      # Allow for one-time initialization if block specified
+      @run_once = false
+      run_once(&block) if block
+    end
+
+    # Call this to run an initialization block once (and only once) for this
+    # Window. Can be called if initialization block wasn't specified when creating Window.
+    # E.g. `win.run_once do |win| ... end`
+    #
+    # @raise ArgumentError if called more than once, or if block already supplied when initializing Window.
+    def run_once
+      return unless block_given?
+      raise(ArgumentError, 'Already initialized') if @run_once
+
+      @run_once = true
+      yield self
     end
 
     # Track open window state in a class instance variable

--- a/test/dsl_spec.rb
+++ b/test/dsl_spec.rb
@@ -2,29 +2,60 @@ require 'ruby2d'
 include Ruby2D::DSL
 
 RSpec.describe Ruby2D::DSL do
+  before do
+    # Need to do this to ensure each test gets a clean DSL
+    DSL.window = nil
+  end
 
-  describe "#get" do
-    it "gets the default window attributes" do
-      expect(get :width).to eq(640)
-      expect(get :height).to eq(480)
-      expect(get :title).to eq("Ruby 2D")
+  describe '#initialize_once' do
+    context 'first call' do
+      before do
+        initialize_once do |w|
+          w.set title: 'Ruby 2D once'
+        end
+      end
+      it 'succeeds' do
+        expect(get(:title)).to eq('Ruby 2D once')
+      end
+    end
+    context 'second attempt' do
+      before do
+        initialize_once do |w|
+          w.set title: 'Ruby 2D once'
+        end
+      end
+      it 'fails' do
+        expect do
+          initialize_once do |w|
+            w.set title: 'Ruby 2D twice'
+          end
+        end.to raise_error
+        expect(get(:title)).not_to eq('Ruby 2D twice')
+      end
     end
   end
 
-  describe "#set" do
-    it "sets a single window attribute" do
+  describe '#get' do
+    it 'gets the default window attributes' do
+      expect(get(:width)).to eq(640)
+      expect(get(:height)).to eq(480)
+      expect(get(:title)).to eq('Ruby 2D')
+    end
+  end
+
+  describe '#set' do
+    it 'sets a single window attribute' do
       set width: 300
-      expect(get :width).to eq(300)
-      expect(get :height).to eq(480)
-      expect(get :title).to eq("Ruby 2D")
+      expect(get(:width)).to eq(300)
+      expect(get(:height)).to eq(480)
+      expect(get(:title)).to eq('Ruby 2D')
     end
 
-    it "sets multiple window attributes at a time" do
-      set width: 800, height: 600, title: "Hello tests!"
-      expect(get :width).to eq(800)
-      expect(get :height).to eq(600)
-      expect(get :title).to eq("Hello tests!")
+    it 'sets multiple window attributes at a time' do
+      set width: 800, height: 600, title: 'Hello tests!'
+      expect(get(:width)).to eq(800)
+      expect(get(:height)).to eq(600)
+      expect(get(:title)).to eq('Hello tests!')
     end
   end
-
 end

--- a/test/dsl_spec.rb
+++ b/test/dsl_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe Ruby2D::DSL do
         end
       end
       it 'fails' do
-        expect do
-          initialize_once do |w|
-            w.set title: 'Ruby 2D twice'
-          end
-        end.to raise_error
+        # second attempt should get ignored
+        initialize_once do |w|
+          w.set title: 'Ruby 2D twice'
+        end
         expect(get(:title)).not_to eq('Ruby 2D twice')
       end
     end


### PR DESCRIPTION
@blacktm, here's a proposal for a one-time init block associated with a Window. I've primarily set it up per Window and then hooked it up to the DSL as well.

* `Window.new` supports optional block that can be used to supply an app-specific init block. I realise that most users don't create a Window directly, but if and when, this is there.
* `Window#run_once`is the underlying method that can also be called if a `Window` is not created with an init block. This exists for use per Window as needed, and this is used by the DSL method.
  * Tweaked to not raise error, so subsequent calls after first one will just be silently discarded
* The `DSL` has a couple of changes:
  * New `#intialize_once` method which in turn passes the block to `Window#run_once`
  * Module starts with `@window=nil` and the `DSL#self.window` method uses memoization pattern to create the Window if none exists. This works because I see that all callers of DSL always call `DSL.window`.
    * This has the added benefit that if someone chooses to not use the DSL and instead create a Window, they can without worrying about a previously automatically created Window.
* Updated the `test/dsl_spec.rb` as follows
  * Set up a `before` block to clear the DSL's window to ensure no side effects across the different contexts.
  * Added a `describe` block to test the `initialize_once` method

For DSL users this should allow the following:
```ruby
require 'ruby2d`

set title: 'My Window'
update do
  initialize_once do |win|
    # once only
    Square.new
    Circle.new
  end

  # do stuff every update
end

show
```

