### PR TITLE
Add the ability to get/remove and replace existing tiles

### DIFF
--- a/lib/ruby2d/tileset.rb
+++ b/lib/ruby2d/tileset.rb
@@ -60,6 +60,39 @@ module Ruby2D
       @tile_definitions[name] = { x: x, y: y, rotate: rotate, flip: flip }
     end
 
+    # Retrieve information about a stamped tile in the tileset by providing its
+    # x and y coordinates
+    # 
+    # @param x [Numeric] The x position of the tile to retrieve
+    # @param y [Numeric] The y position of the tile to retrieve
+    def get_tile(x, y)
+      @tiles.detect do |tile|
+        tile.fetch(:x) == x && tile.fetch(:y) == y
+      end
+    end
+
+    # Remove a single stamped tile at the location x,y, removing it from the tileset
+    # 
+    # @param x [Numeric] The x position of the tile to retrieve
+    # @param y [Numeric] The y position of the tile to retrieve
+    def remove_tile(x, y)
+      @tiles.delete_if do |tile|
+        tile.fetch(:x) == x && tile.fetch(:y) == y
+      end
+    end
+
+    # Remove tiles and replace them with new ones that are "stamped" in their place
+    #
+    # @param name [String] The name of the tile defined using +#define_tile+
+    # @param coordinates [Array<{"x", "y" => Numeric}>] one or more +{x:, y:}+ coordinates to draw the tile
+    def replace_tiles(name, coordinates)
+      coordinates.each do |coordinate|
+        remove_tile(coordinate.fetch(:x), coordinate.fetch(:y))
+      end
+
+      set_tile(name, coordinates)
+    end
+
     # Select and "stamp" or set/place a tile to be drawn
     # @param name [String] The name of the tile defined using +#define_tile+
     # @param coordinates [Array<{"x", "y" => Numeric}>] one or more +{x:, y:}+ coordinates to draw the tile
@@ -83,6 +116,9 @@ module Ruby2D
         # them all due to change to scale etc (currently n/a since
         # scale is immutable)
         @tiles.push({
+                      name: name,
+                      x: coordinate.fetch(:x),
+                      y: coordinate.fetch(:y),
                       tile_def: tile_def,
                       vertices: vertices
                     })

--- a/test/tileset.rb
+++ b/test/tileset.rb
@@ -11,9 +11,16 @@ class GameWindow < Ruby2D::Window
     set height: 135 * SCALE
     set background: 'white'
     @tileset = Tileset.new("#{Ruby2D.test_media}/texture_atlas.png", tile_width: TILE_WIDTH, tile_height: TILE_HEIGHT, scale: SCALE)
-  end
 
-  def update
+    on :mouse_down do |action|
+      x = (action.x / SCALE / TILE_WIDTH) * TILE_WIDTH * SCALE
+      y = (action.y / SCALE / TILE_HEIGHT) * TILE_HEIGHT * SCALE
+
+      tile = @tileset.get_tile(x, y)
+      next_num = ['num-1', 'num-2', 'num-3'].cycle(2).to_a[tile.fetch(:name)[-1].to_i]
+      @tileset.replace_tiles(next_num, [{x: x, y: y}])
+    end
+
     @tileset.clear_tiles
 
     @tileset.define_tile('num-1', 0, 0, flip: :both)
@@ -37,6 +44,9 @@ class GameWindow < Ruby2D::Window
       {x: TILE_WIDTH * SCALE * 1, y: TILE_HEIGHT * SCALE * 0},
       {x: TILE_WIDTH * SCALE * 2, y: TILE_HEIGHT * SCALE * 1},
     ])
+  end
+
+  def update
   end
 
   def render


### PR DESCRIPTION
When the tileset feature was added, the idea was that you would clear all of the tiles before painting new ones, this proves to be costly from a performance standpoint, so instead it's easier if we can sub out a single tile for a new one.

The tilesets are kept in an array which we need to scan to remove tiles, I think at the moment this will likely be ok for performance, we can sub out the array for a hash keyed by the x+y coordinates of the tile; though retrieving the hash values for rendering might incur some memory copy cost as well, so happy to change it if we feel necessary.


## Example

In this example we can read the current name of the tile using `get_tile`, which is either `num-1`, `num-2` or `num-3`, then replace that tile with a new tile using the `replace_tiles` method which has the same API signature as `set_tiles`. This allows cycling through numbers :)

https://user-images.githubusercontent.com/112153/217129982-eb2c4dcb-7ce3-4832-a0be-59f05497ee23.mov

