### PR TITLE
Add functionality to set FORCE_GL2 from environment variable

### DIFF
--- a/ext/ruby2d/gl.c
+++ b/ext/ruby2d/gl.c
@@ -210,6 +210,14 @@ void R2D_GL_SetViewport(R2D_Window *window) {
  */
 int R2D_GL_Init(R2D_Window *window) {
 
+  const char* env_force_gl2 = getenv("FORCE_GL2");
+  if (env_force_gl2 != NULL){
+    if (strcmp(env_force_gl2, "true") == 0){
+      FORCE_GL2 = true;
+      R2D_GL2 = true;
+    }
+  }
+
   // Specify OpenGL contexts and set attributes
   #if GLES
     SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   8);


### PR DESCRIPTION
Intel(R) HD Graphics 3000
OpenGL
Version: 3.1.0 - Build 9.17.10.4459
Driver version: Intel Graphics Driver 9.17.10.4459 5-19-2016

I ran into an issue where "glGenVertexArrays(1, &vao);" failed on my system. I saw that there was built-in functionality to force OpenGL version 2 but no way of setting it without recompiling.

This pull request adds code to allow forcing ruby2d to use OpenGL version 2 from an environment variable.