### PR TITLE
Add configuration for YARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ test/screenshot*
 Gemfile.lock
 .DS_Store
 tmp*
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 build/
+doc/
+.yardoc/
 test/screenshot*
 *.gem
 Gemfile.lock
 .DS_Store
 tmp*
+

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+lib/**/*.rb - README.md CODE_OF_CONDUCT.md LICENSE.md


### PR DESCRIPTION
Hello, this PR objective is to add a YARD options file so I don't need to run `yardoc lib/**/*.rb ...` everytime I need to generate the docs, the ones in [rubydoc.info](https://www.rubydoc.info/gems/ruby2d/0.4.1/Ruby2D) aren't exactly great, part of the documentation seems to be lost there?

## Changes

The `.yardopts` file that documents everything under `lib/`, and also bundles `README.md`, `CODE_OF_CONDUCT.md` and `LICENSE.md`. Apart from that I've also added some new ignore directives, to ignore the generated `.yardoc/` and `doc/` directories.

The `.yardoc/` directory is used as a cache by YARD, as to do incremental documentation generation and other stuff that's documented [here](https://rubydoc.info/gems/yard/YARD/CLI/Yardoc) (scroll down to processed data storage).

## Misc

[Link to YARD docs on generating documentation](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#using-yard-to-generate-documentation)

